### PR TITLE
docs: Step about the environment variables file

### DIFF
--- a/docs/instalacao.md
+++ b/docs/instalacao.md
@@ -43,7 +43,8 @@ Gere o arquivo com as variáveis de ambiente baseado no arquivo de exemplo:
 $ cp .env.sample .env
 ```
 
-Todas as configurações são passadas via variáveis de ambiente e estão documentadas no `--help` da aplicação.
+Todas as configurações podem ser sobrescritas via variáveis de ambiente e estão documentadas no `--help` da aplicação.
+
 
 ### Exemplo
 

--- a/docs/instalacao.md
+++ b/docs/instalacao.md
@@ -45,7 +45,6 @@ $ cp .env.sample .env
 
 Todas as configurações podem ser sobrescritas via variáveis de ambiente e estão documentadas no `--help` da aplicação.
 
-
 ### Exemplo
 
 Sem Docker:

--- a/docs/instalacao.md
+++ b/docs/instalacao.md
@@ -37,6 +37,12 @@ $ docker-compose build
 
 ## Configurações
 
+Gere o arquivo com as variáveis de ambiente baseado no arquivo de exemplo:
+
+```console
+$ cp .env.sample .env
+```
+
 Todas as configurações são passadas via variáveis de ambiente e estão documentadas no `--help` da aplicação.
 
 ### Exemplo


### PR DESCRIPTION
Opa!

Ao tentar rodar o projeto utilizando docker recebi um erro de que o arquivo `.env` não pôde ser encontrado. Então tô subindo esse PR pois acredito que faltou uma etapa na documentação e no guideline de contribuição onde é indicado gerar o arquivo que contém as variáveis de ambiente.

Ps. Estou tentando gerar a documentação utilizando: `docker run --rm -v ~/dev/minha-receita/docs/ squidfunk/mkdocs-material build` e estou recebendo esse erro: `Config file '/docs/mkdocs.yml' does not exist.`. Será que tem algum problema com meu docker local? (Posso criar uma issue não seja algo pontual referente a esse PR).

Passos que fiz:

```
docker pull squidfunk/mkdocs-material
docker-compose build
docker run --rm -v ~/dev/minha-receita/docs/ squidfunk/mkdocs-material build
``` 