### PR TITLE
Compatibilidade reversa (via HTTP status 303)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -42,7 +42,7 @@ type api struct {
 	db db.Database
 }
 
-func (app api) postHandler(w http.ResponseWriter, r *http.Request) {
+func (app api) getHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-type", "application/json")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
@@ -53,24 +53,19 @@ func (app api) postHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.Method != http.MethodPost {
-		messageResponse(w, http.StatusMethodNotAllowed, "Essa URL aceita apenas o método POST.")
+	if r.Method != http.MethodGet {
+		messageResponse(w, http.StatusMethodNotAllowed, "Essa URL aceita apenas o método GET.")
 		return
 	}
 
-	if err := r.ParseForm(); err != nil {
-		messageResponse(w, http.StatusBadRequest, "Conteúdo inválido na requisição POST.")
-		return
-	}
-
-	v := r.Form.Get("cnpj")
-	if v == "" {
-		messageResponse(w, http.StatusBadRequest, "CNPJ não enviado na requisição POST.")
+	v := r.URL.Path
+	if v == "/" {
+		messageResponse(w, http.StatusBadRequest, "CNPJ não enviado na requisição GET.")
 		return
 	}
 
 	if !cnpj.IsValid(v) {
-		messageResponse(w, http.StatusBadRequest, fmt.Sprintf("CNPJ %s inválido.", cnpj.Mask(v)))
+		messageResponse(w, http.StatusBadRequest, fmt.Sprintf("CNPJ %s inválido.", cnpj.Mask(v[1:])))
 		return
 	}
 
@@ -111,7 +106,7 @@ func Serve(db db.Database) {
 
 	nr := newRelicApp()
 	app := api{db: db}
-	http.HandleFunc(newRelicHandle(nr, "/", app.postHandler))
+	http.HandleFunc(newRelicHandle(nr, "/", app.getHandler))
 	http.HandleFunc(newRelicHandle(nr, "/healthz", app.healthHandler))
 	log.Fatal(http.ListenAndServe(port, nil))
 }

--- a/api/api.go
+++ b/api/api.go
@@ -97,7 +97,7 @@ func (app api) companyHandler(w http.ResponseWriter, r *http.Request) {
 
 	c, err := app.db.GetCompany(cnpj.Unmask(v))
 	if err != nil {
-		messageResponse(w, http.StatusNoContent, "")
+		messageResponse(w, http.StatusNotFound, fmt.Sprintf("CNPJ %s não encontrado.", cnpj.Mask(v)))
 		return
 	}
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -90,14 +90,14 @@ func TestCompanyHandler(t *testing.T) {
 		{
 			http.MethodGet,
 			"/00.000.000/0001-91",
-			http.StatusNoContent,
-			"",
+			http.StatusNotFound,
+			`{"message":"CNPJ 00.000.000/0001-91 não encontrado."}`,
 		},
 		{
 			http.MethodGet,
 			"/00000000000191",
-			http.StatusNoContent,
-			"",
+			http.StatusNotFound,
+			`{"message":"CNPJ 00.000.000/0001-91 não encontrado."}`,
 		},
 		{
 			http.MethodGet,

--- a/docs/cliente.md
+++ b/docs/cliente.md
@@ -4,21 +4,20 @@ A API web tem apenas dois _endpoints_:
 
 ## `POST /`
 
-| Caminho da URL | Tipo de requisição | Dados enviados | Código esperado na resposta | Conteúdo esperado na resposta |
-|---|---|---|---|---|
-| `/` | `GET` | | 405 | `{"message": "Essa URL aceita apenas o método POST."}` |
-| `/` | `HEAD` | | 405 | `{"message": "Essa URL aceita apenas o método POST."}` |
-| `/` | `POST` | | 400 | `{"message": "conteúdo inválido na requisição POST."}` |
-| `/` | `POST` | `cpf=foobar` | 400 | `{"message": "CNPJ não enviado na requisição POST."}` |
-| `/` | `POST` | `cnpj=foobar` | 400 | `{"message": "CNPJ foobar inválido."}` |
-| `/` | `POST` | `cnpj=00000000000000` | 204 | _Corpo vazio, significa que o CNPJ é válido mas não consta no banco de dados._ |
-| `/` | `POST` | `cnpj=19131243000197` | 200 | _Ver JSON de exemplo abaixo._ |
-| `/` | `POST` | `cnpj=19.131.243/0001-97` | 200 | _Ver JSON de exemplo abaixo._ |
+| Caminho da URL | Tipo de requisição | Código esperado na resposta | Conteúdo esperado na resposta |
+|---|---|---|---|
+| `/` | `POST` | 405 | `{"message": "Essa URL aceita apenas o método GET."}` |
+| `/` | `HEAD` | 405 | `{"message": "Essa URL aceita apenas o método GET."}` |
+| `/` | `GET` | 400 | `{"message": "CNPJ não enviado na requisição GET."}` |
+| `/foobar` | `GET` | 400 | `{"message": "CNPJ foobar inválido."}` |
+| `/00000000000000` | `GET` | 204 | _Corpo vazio, significa que o CNPJ é válido mas não consta no banco de dados._ |
+| `/19131243000197` | `GET` | 200 | _Ver JSON de exemplo abaixo._ |
+| `/19.131.243/0001-97` | `GET` | 200 | _Ver JSON de exemplo abaixo._ |
 
 ### Exemplo de requisição usando o `curl`
 
 ```console
-$ curl -i -X POST -d cnpj=19131243000197 0.0.0.0:8000
+$ curl -i 0.0.0.0:8000/19131243000197
 ```
 
 ### Exemplo de resposta válida

--- a/docs/cliente.md
+++ b/docs/cliente.md
@@ -10,7 +10,8 @@ A API web tem apenas dois _endpoints_:
 | `/` | `HEAD` | 405 | `{"message": "Essa URL aceita apenas o método GET."}` |
 | `/` | `GET` | 400 | `{"message": "CNPJ não enviado na requisição GET."}` |
 | `/foobar` | `GET` | 400 | `{"message": "CNPJ foobar inválido."}` |
-| `/00000000000000` | `GET` | 204 | _Corpo vazio, significa que o CNPJ é válido mas não consta no banco de dados._ |
+| `/00000000000000` | `GET` | 404 | `{"message": "CNPJ 00.000.000/0000-00 não encontrado."}`  |
+| `/00.000.000/0000-00` | `GET` | 404 | `{"message": "CNPJ 00.000.000/0000-00 não encontrado."}`  |
 | `/19131243000197` | `GET` | 200 | _Ver JSON de exemplo abaixo._ |
 | `/19.131.243/0001-97` | `GET` | 200 | _Ver JSON de exemplo abaixo._ |
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cuducos/minha-receita
 
-go 1.15
+go 1.16
 
 require (
 	github.com/360EntSecGroup-Skylar/excelize/v2 v2.3.1

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/matryer/is v0.0.0-20170112134659-c0323ceb4e99 h1:cIAyXQXBuSY59PAN6nK4tnaeUcATlXS/GRNCKA1+JB0=
 github.com/matryer/is v0.0.0-20170112134659-c0323ceb4e99/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=


### PR DESCRIPTION


**Contexto**

Mudança do método proncipal de POST para GET proposto em #29 e implementado em #35.

**Propósito**

Como descrito em #36, adiciona compatibilidade reversa.

**Solução**

Ao se deparar com um método diferente de `GET`, testamos se a requisição seria uma requisição válida para a API antiga e, caso positivo, retornamos um redirecionamento com HTTP status 303.