### PR TITLE
Cria ferramentas para mapear número de CNPJ a caminho de arquivos e vice-versa

### DIFF
--- a/transform/fs.go
+++ b/transform/fs.go
@@ -1,0 +1,37 @@
+package transform
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cuducos/go-cnpj"
+)
+
+var InvalidCNPJError = errors.New("Invalid CNPJ")
+var InvalidPathError = errors.New("Invalid path for a CNPJ JSON file")
+
+func PathForCNPJ(c string) (string, error) {
+	if !cnpj.IsValid(c) {
+		return "", fmt.Errorf("Error finding file path for %s: %w", c, InvalidCNPJError)
+	}
+
+	c = cnpj.Unmask(c)
+	return c[:8] + string(os.PathSeparator) + c[8:] + ".json", nil
+}
+
+func CNPJForPath(p string) (string, error) {
+	c := strings.Split(p, string(os.PathSeparator))
+	if len(c) < 2 {
+		return "", fmt.Errorf("Error finding the CNPJ for %s: %w", p, InvalidPathError)
+	}
+
+	r := c[len(c)-2] + strings.TrimSuffix(c[len(c)-1], filepath.Ext(p))
+	if !cnpj.IsValid(r) {
+		return "", fmt.Errorf("Error finding the CNPJ for %s: %w", p, InvalidPathError)
+	}
+
+	return r, nil
+}

--- a/transform/fs_test.go
+++ b/transform/fs_test.go
@@ -1,0 +1,50 @@
+package transform
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPathFor(t *testing.T) {
+	tt := []struct {
+		cnpj string
+		path string
+		err  error
+	}{
+		{"19131243000197", "19131243/000197.json", nil},
+		{"19.131.243/0001-97", "19131243/000197.json", nil},
+		{"foobar", "", InvalidCNPJError},
+		{"12345678901234", "", InvalidCNPJError},
+		{"12.345.678/9012-34", "", InvalidCNPJError},
+	}
+	for _, c := range tt {
+		got, err := PathForCNPJ(c.cnpj)
+		if got != c.path {
+			t.Errorf("expected path for %s to be %s, got %s", c.cnpj, c.path, got)
+		}
+		if !errors.Is(err, c.err) {
+			t.Errorf("expected %v as an error for %s, got %v", c.err, c.cnpj, err)
+		}
+	}
+}
+
+func TestCNPJFor(t *testing.T) {
+	tt := []struct {
+		path string
+		cnpj string
+		err  error
+	}{
+		{"19131243/000197.json", "19131243000197", nil},
+		{"/home/user/data/19131243/000197.json", "19131243000197", nil},
+		{"19/131.json", "", InvalidPathError},
+	}
+	for _, c := range tt {
+		got, err := CNPJForPath(c.path)
+		if got != c.cnpj {
+			t.Errorf("expected cnpj for %s to be %s, got %s", c.path, c.cnpj, got)
+		}
+		if !errors.Is(err, c.err) {
+			t.Errorf("expected %v as an error for %s, got %v", c.err, c.path, err)
+		}
+	}
+}


### PR DESCRIPTION
De acordo com a estraégia descrita em #37 precisamos de ferramentas para mapear um número de CNPJ a um diretório e arquivo:

> dado um CNPJ 11.222.333/0001-81, a estratégia é criar arquivo como `tmp/11222333/11222333000181.json`

Esse PR sugere a implementação de funções para mapear esses valores.