### PR TITLE
Refactoring newRelicHandle signature

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/cuducos/go-cnpj"
-
 	"github.com/cuducos/minha-receita/db"
 )
 
@@ -23,7 +22,7 @@ type errorMessage struct {
 }
 
 // messageResponse takes a text message and a HTP status, wraps the message into a
-// JSON output and writes it toghether with the proper headers to a response.
+// JSON output and writes it together with the proper headers to a response.
 func messageResponse(w http.ResponseWriter, s int, m string) {
 	w.WriteHeader(s)
 	if m == "" {

--- a/api/new_relic.go
+++ b/api/new_relic.go
@@ -23,9 +23,10 @@ func newRelicApp() *newrelic.Application {
 	return app
 }
 
-func newRelicHandle(app *newrelic.Application, pth string, f func(http.ResponseWriter, *http.Request)) (string, func(http.ResponseWriter, *http.Request)) {
+func newRelicHandle(app *newrelic.Application, pth string, f http.HandlerFunc) (string, http.HandlerFunc) {
 	if app == nil {
 		return pth, f
 	}
+
 	return newrelic.WrapHandleFunc(app, pth, f)
 }

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -16,7 +16,7 @@ type PostgreSQL struct {
 	schema string
 }
 
-// Close ends the conection with the database.
+// Close ends the connection with the database.
 func (p *PostgreSQL) Close() {
 	p.conn.Close()
 }


### PR DESCRIPTION
This PR fix some comment typos and refactoring `newRelicHandle` function signature, using the type interfaces from `net/http` instead of closure signature.