### PR TITLE
Cria funções para coercão de tipos

### DIFF
--- a/transform/cast.go
+++ b/transform/cast.go
@@ -1,0 +1,48 @@
+package transform
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func toInt(v string) (*int, error) {
+	if v == "" {
+		return nil, nil
+	}
+
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return nil, fmt.Errorf("error converting %s to int: %w", v, err)
+	}
+
+	return &i, nil
+}
+
+func toFloat(v string) (*float32, error) {
+	if v == "" {
+		return nil, nil
+	}
+
+	f, err := strconv.ParseFloat(strings.ReplaceAll(v, ",", "."), 32)
+	if err != nil {
+		return nil, fmt.Errorf("error converting %s to float32: %w", v, err)
+	}
+
+	f32 := float32(f)
+	return &f32, nil
+}
+
+func toTime(v string) (*time.Time, error) {
+	if v == "" {
+		return nil, nil
+	}
+
+	t, err := time.Parse("20060102", v)
+	if err != nil {
+		return nil, fmt.Errorf("error converting %s to Time: %w", v, err)
+	}
+
+	return &t, nil
+}

--- a/transform/cast.go
+++ b/transform/cast.go
@@ -1,3 +1,13 @@
+// These functions allow the project to accomplish two things:
+// * convert strings from the CSV files to other formats (e.g. int, float32,
+//   time.Time);
+// * differentiate empty values (such as 0 for int) from missing values.
+//
+// This is achieved using pointers, so we have nil as a marker for missing
+// value.
+// Since our use case involves serving this data in JSON file, this is crucial
+// so we can use `null` when there is no value, and "0" when the value of an
+// integer, for example, is 0.
 package transform
 
 import (
@@ -34,6 +44,8 @@ func toFloat(v string) (*float32, error) {
 	return &f32, nil
 }
 
+// toTime expects a date as string in the format YYYYMMDD (that is the format
+// used by the Federal Revenue in their CSV files).
 func toTime(v string) (*time.Time, error) {
 	if v == "" {
 		return nil, nil

--- a/transform/cast_test.go
+++ b/transform/cast_test.go
@@ -1,0 +1,121 @@
+package transform
+
+import (
+	"testing"
+	"time"
+)
+
+func TestToInt(t *testing.T) {
+	t.Run("successful *int casting", func(t *testing.T) {
+		n := 42
+		tc := []struct {
+			value    string
+			expected *int
+		}{
+			{"42", &n},
+			{"", nil},
+		}
+		for _, c := range tc {
+			got, err := toInt(c.value)
+			if err != nil {
+				t.Errorf("expected no errors when converting %s to *int, got %s", c.value, err)
+			}
+			if c.expected != nil {
+				if *got != *c.expected {
+					t.Errorf("got %d, expected %d", *got, *c.expected)
+				}
+			} else {
+				if got != c.expected {
+					t.Errorf("got %d, expected nil", *got)
+				}
+			}
+		}
+	})
+
+	t.Run("unsuccessful *int casting", func(t *testing.T) {
+		tc := []string{"4.2", "foobar"}
+		for _, v := range tc {
+			_, err := toInt(v)
+			if err == nil {
+				t.Errorf("expected a error when converting %s to *int, got ni", v)
+			}
+		}
+	})
+}
+
+func TestToFloat(t *testing.T) {
+	t.Run("successful *float32 casting", func(t *testing.T) {
+		n1 := float32(42)
+		n2 := float32(0.42)
+		tc := []struct {
+			value    string
+			expected *float32
+		}{
+			{"42", &n1},
+			{"0.42", &n2},
+			{"", nil},
+		}
+		for _, c := range tc {
+			got, err := toFloat(c.value)
+			if err != nil {
+				t.Errorf("expected no errors when converting %s to *float32, got %s", c.value, err)
+			}
+			if c.expected != nil {
+				if *got != *c.expected {
+					t.Errorf("got %f, expected %f", *got, *c.expected)
+				}
+			} else {
+				if got != c.expected {
+					t.Errorf("got %f, expected nil", *got)
+				}
+			}
+		}
+	})
+
+	t.Run("unsuccessful *float32 casting", func(t *testing.T) {
+		_, err := toFloat("foobar")
+		if err == nil {
+			t.Errorf("expected a error when converting foobar to *float32, got nil")
+		}
+	})
+}
+
+func TestToTime(t *testing.T) {
+	t.Run("successful *time.Time casting", func(t *testing.T) {
+		v := "19940717"
+		expected, err := time.Parse("20060102", v)
+		if err != nil {
+			t.Errorf("could not create a time.Time for the test")
+		}
+
+		tc := []struct {
+			value    string
+			expected *time.Time
+		}{
+			{v, &expected},
+			{"", nil},
+		}
+		for _, c := range tc {
+			got, err := toTime(c.value)
+			if err != nil {
+				t.Errorf("expected no errors when converting %s to *time.Time, got %s", c.value, err)
+			}
+			if c.expected != nil {
+				if *got != *c.expected {
+					t.Errorf("got %q, expected %q", *got, *c.expected)
+				}
+			} else {
+				if got != c.expected {
+					t.Errorf("got %q, expected nil", *got)
+				}
+			}
+		}
+	})
+
+	t.Run("unsuccessful *time.Time casting", func(t *testing.T) {
+		_, err := toTime("foobar")
+		if err == nil {
+			t.Errorf("expected a error when converting foobar to *time.Time, got nil")
+		}
+	})
+}


### PR DESCRIPTION
**Contexto**

No escopo do #37, pretendo utilizar `*int`, `*string` etc. como tipos na hora de criar o JSON. Isso permite que a gente diferencie um texto vazio (`""`) ou `0` de `null` no JSON. Apesar disso, como os valroes vem de um CSV, todos eles são, originalmente `string` — e por isso precisamos fazer essa coerção de tipos.

**Sugestão**

Criei funções euxiliares em `transform/cast.go` para converter de `string` (vinda do CSV) para `*int`, `*float32` e `*time.Tme` respectivamente.