### PR TITLE
Atualiza CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,6 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.15"
+          go-version: "1.16"
       - run: "go test ./..."
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,5 +8,5 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.15"
-      - run: "cd api && go test ./..."
+      - run: "go test ./..."
 


### PR DESCRIPTION
Atualiza versão do Go para 1.16 na CI e corrige bug que fazia com que só rodássemos parte dos testes.