### PR TITLE
Cria estrutura para mais estruturas de “look up”

### DIFF
--- a/transform/archive.go
+++ b/transform/archive.go
@@ -66,7 +66,7 @@ func (a *archivedCSV) close() error {
 	return nil
 }
 
-func (a *archivedCSV) toMap() (map[int]string, error) {
+func (a *archivedCSV) toLookup() (lookup, error) {
 	m := make(map[int]string)
 	for {
 		l, err := a.read()

--- a/transform/archive_test.go
+++ b/transform/archive_test.go
@@ -49,8 +49,8 @@ func TestArchivedCSV(t *testing.T) {
 	})
 }
 
-func TestArchivedCSVToMap(t *testing.T) {
-	expected := make(map[int]string)
+func TestArchivedCSVToLookup(t *testing.T) {
+	expected := make(lookup)
 	expected[0] = "SEM MOTIVO"
 	expected[1] = "EXTINCAO POR ENCERRAMENTO LIQUIDACAO VOLUNTARIA"
 

--- a/transform/archive_test.go
+++ b/transform/archive_test.go
@@ -60,7 +60,7 @@ func TestArchivedCSVToMap(t *testing.T) {
 	}
 	defer z.close()
 
-	got, err := z.toMap()
+	got, err := z.toLookup()
 	if err != nil {
 		t.Errorf("expected no error with %s, got %s", path, err)
 	}

--- a/transform/company.go
+++ b/transform/company.go
@@ -114,21 +114,7 @@ func (c *company) cnaeSecundarios(v string) error {
 	return nil
 }
 
-func (c *company) motivoSituacaoCadastral(motives map[int]string, v string) error {
-	i, err := toInt(v)
-	if err != nil {
-		return fmt.Errorf("error trying to parse MotivoSituacaoCadastral %s: %w", v, err)
-	}
-
-	s := motives[*i]
-	c.MotivoSituacaoCadastral = i
-	if s != "" {
-		c.DescricaoMotivoSituacaoCadastral = &s
-	}
-	return nil
-}
-
-func newCompany(row []string, motives map[int]string) (company, error) {
+func newCompany(row []string, l lookups) (company, error) {
 	var c company
 	c.CNPJ = row[0] + row[1] + row[2]
 	c.NomeFantasia = row[4]
@@ -162,7 +148,7 @@ func newCompany(row []string, motives map[int]string) (company, error) {
 	}
 	c.DataSituacaoCadastral = dataSituacaoCadastral
 
-	if err := c.motivoSituacaoCadastral(motives, row[7]); err != nil {
+	if err := c.motivoSituacaoCadastral(l, row[7]); err != nil {
 		return c, fmt.Errorf("error trying to parse MotivoSituacaoCadastral: %w", err)
 	}
 

--- a/transform/company_test.go
+++ b/transform/company_test.go
@@ -49,14 +49,14 @@ func TestNewCompany(t *testing.T) {
 	descricaoSituacaoCadastral := "ATIVA"
 	dataSituacaoCadastralAsTime, err := time.Parse(dateInputFormat, row[6])
 	if err != nil {
-		t.Errorf("error creating DataSituacaoCadastral for expected company: %w", err)
+		t.Errorf("error creating DataSituacaoCadastral for expected company: %s", err)
 	}
 	dataSituacaoCadastral := date(dataSituacaoCadastralAsTime)
 	motivoSituacaoCadastral := 0
 	descricaoMotivoSituacaoCadastral := "SEM MOTIVO"
 	dataInicioAtividadeAsTime, err := time.Parse(dateInputFormat, row[10])
 	if err != nil {
-		t.Errorf("error creating DataInicioAtividade for expected company: %w", err)
+		t.Errorf("error creating DataInicioAtividade for expected company: %s", err)
 	}
 	dataInicioAtividade := date(dataInicioAtividadeAsTime)
 	codigoCNAEFiscal := 6204000
@@ -104,12 +104,13 @@ func TestNewCompany(t *testing.T) {
 	}
 	defer z.close()
 
-	motives, err := z.toMap()
+	var lookups lookups
+	lookups.motives, err = z.toMap()
 	if err != nil {
 		t.Errorf("error creating motives lookup table: %s", err)
 	}
 
-	got, err := newCompany(row, motives)
+	got, err := newCompany(row, lookups)
 	if err != nil {
 		t.Errorf("expected no errors, got %v", err)
 	}
@@ -225,7 +226,7 @@ func TestCompanyToJson(t *testing.T) {
 
 	dataInicioAtividadeAsTime, err := time.Parse(dateInputFormat, "19670630")
 	if err != nil {
-		t.Errorf("error creating DataInicioAtividade for expected company: %w", err)
+		t.Errorf("error creating DataInicioAtividade for expected company: %s", err)
 	}
 	dataInicioAtividade := date(dataInicioAtividadeAsTime)
 	c := company{

--- a/transform/company_test.go
+++ b/transform/company_test.go
@@ -105,7 +105,7 @@ func TestNewCompany(t *testing.T) {
 	defer z.close()
 
 	var lookups lookups
-	lookups.motives, err = z.toMap()
+	lookups.motives, err = z.toLookup()
 	if err != nil {
 		t.Errorf("error creating motives lookup table: %s", err)
 	}

--- a/transform/lookups.go
+++ b/transform/lookups.go
@@ -1,0 +1,27 @@
+package transform
+
+import "fmt"
+
+type lookup map[int]string
+
+type lookups struct {
+	motives lookup
+}
+
+func newLookups() lookups {
+	return lookups{motives: make(map[int]string)}
+}
+
+func (c *company) motivoSituacaoCadastral(l lookups, v string) error {
+	i, err := toInt(v)
+	if err != nil {
+		return fmt.Errorf("error trying to parse MotivoSituacaoCadastral %s: %w", v, err)
+	}
+
+	s := l.motives[*i]
+	c.MotivoSituacaoCadastral = i
+	if s != "" {
+		c.DescricaoMotivoSituacaoCadastral = &s
+	}
+	return nil
+}

--- a/transform/path.go
+++ b/transform/path.go
@@ -13,21 +13,6 @@ import (
 var InvalidCNPJError = errors.New("Invalid CNPJ")
 var InvalidPathError = errors.New("Invalid path for a CNPJ JSON file")
 
-type sourceType string
-
-const (
-	venue         sourceType = "ESTABELE"
-	motive                   = "MOTICSV"
-	main                     = "EMPRECSV"
-	city                     = "MUNICCSV"
-	cnae                     = "CNAECSV"
-	country                  = "PAISCSV"
-	nature                   = "NATJUCSV"
-	partner                  = "SOCIOCSV"
-	qualification            = "QUALSCSV"
-	simple                   = "SIMPLES"
-)
-
 func PathsForSource(t sourceType, dir string) ([]string, error) {
 	var ls []string
 

--- a/transform/source.go
+++ b/transform/source.go
@@ -5,6 +5,21 @@ import (
 	"io"
 )
 
+type sourceType string
+
+const (
+	venue         sourceType = "ESTABELE"
+	motive                   = "MOTICSV"
+	main                     = "EMPRECSV"
+	city                     = "MUNICCSV"
+	cnae                     = "CNAECSV"
+	country                  = "PAISCSV"
+	nature                   = "NATJUCSV"
+	partner                  = "SOCIOCSV"
+	qualification            = "QUALSCSV"
+	simple                   = "SIMPLES"
+)
+
 type lineCount struct {
 	total int64
 	err   error

--- a/transform/task.go
+++ b/transform/task.go
@@ -9,11 +9,11 @@ import (
 
 type task struct {
 	source  *source
+	lookups lookups
 	queue   chan []string
 	paths   chan string
 	errors  chan error
 	bar     *progressbar.ProgressBar
-	motives map[int]string
 }
 
 func (t *task) loadMotives(d string, s rune) error {
@@ -31,7 +31,7 @@ func (t *task) loadMotives(d string, s rune) error {
 		return fmt.Errorf("error loading archived CSV to build a map: %w", err)
 	}
 	defer z.close()
-	t.motives, err = z.toMap()
+	t.lookups.motives, err = z.toMap()
 	if err != nil {
 		return fmt.Errorf("error creating motives lookup map: %w", err)
 	}
@@ -58,7 +58,7 @@ func (t *task) produceRows() {
 
 func (t *task) consumeRows() {
 	for r := range t.queue {
-		c, err := newCompany(r, t.motives)
+		c, err := newCompany(r, t.lookups)
 		if err != nil {
 			t.errors <- fmt.Errorf("error parsing company from %q: %w", r, err)
 			break

--- a/transform/task.go
+++ b/transform/task.go
@@ -31,7 +31,7 @@ func (t *task) loadMotives(d string, s rune) error {
 		return fmt.Errorf("error loading archived CSV to build a map: %w", err)
 	}
 	defer z.close()
-	t.lookups.motives, err = z.toMap()
+	t.lookups.motives, err = z.toLookup()
 	if err != nil {
 		return fmt.Errorf("error creating motives lookup map: %w", err)
 	}


### PR DESCRIPTION
**Aviso**: Esse PR depende do #62. Caso o #62 seja _mergeado_ primeiro, eu mudo a base desse PR para `dev`.

Esse PR refatora alguns pontos do #62 para criar uma estrutura que acomode mais estruturas de _look up_.

A ideia foi mover a lógica utilizada para o CSV de “motivo de situação cadastral” para um novo `struct`, um que acomode (no futuro) estruturas de _look up_ para todos os casos de uso descritos na #37: CNAEs, Simples, municípios, países etc.

A ideia é deixar o código para essa implementação mais claro e fácil de manter.