### PR TITLE
Lida com typo no site da Receita Federal

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -48,7 +48,7 @@ func getURLs(client *http.Client, src string) ([]string, error) {
 			return
 		}
 		if strings.HasSuffix(h, ".zip") {
-			urls = append(urls, h)
+			urls = append(urls, strings.ReplaceAll(h, "https//", "https://"))
 		}
 	})
 	return urls, nil


### PR DESCRIPTION
Como já é a sehunda vez que vejo URLs no site da Receita Federal com esse mesmo _typo_, acho que faz sentido nos prepararmos para isso:

```
Error sending a HTTP HEAD request to http://http//200.152.38.155/CNPJ/K3241.K03200Y1.D11113.SOCIOCSV.zip: Head "http://http//200.152.38.155/CNPJ/K3241.K03200Y1.D11113.SOCIOCSV.zip": dial tcp: lookup http: no such host
exit status 1
```

A sugestão é substituir `https//` por `https://` em toda URL coletada.