### PR TITLE
Remove arquivo do IBGE com descrição dos CNAEs

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -17,7 +17,6 @@ import (
 )
 
 const federalRevenue = "https://www.gov.br/receitafederal/pt-br/assuntos/orientacao-tributaria/cadastros/consultas/dados-publicos-cnpj"
-const listOfCNAE = "https://cnae.ibge.gov.br/images/concla/documentacao/CNAE_Subclasses_2_3_Estrutura_Detalhada.xlsx"
 const retries = 10
 
 type file struct {
@@ -55,16 +54,11 @@ func getURLs(client *http.Client, src string) ([]string, error) {
 }
 
 func getFiles(client *http.Client, src, dir string) ([]file, error) {
-	fs := []file{{
-		url:  listOfCNAE,
-		path: filepath.Join(dir, "CNAE_Subclasses_2_3_Estrutura_Detalhada.xlsx"),
-	}}
-
+	var fs []file
 	urls, err := getURLs(client, src)
 	if err != nil {
 		return fs, err
 	}
-
 	for _, u := range urls {
 		fs = append(fs, file{url: u, path: filepath.Join(dir, u[strings.LastIndex(u, "/")+1:])})
 	}
@@ -84,14 +78,6 @@ type size struct {
 }
 
 func (d *downloader) getSize(ch chan<- size, url string) {
-	// We use a HTTP HEAD request to get the file size, but IBGE server does
-	// not respond properly to that. Thus, as a temporary workaround we just
-	// hardcoded the current file size (checked manually after downloading it)
-	if url == listOfCNAE {
-		ch <- size{size: 137216}
-		return
-	}
-
 	r, err := d.client.Head(url)
 	if err != nil {
 		ch <- size{err: fmt.Errorf("Error sending a HTTP HEAD request to %s: %s", url, err)}

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -69,14 +69,8 @@ func TestGetFiles(t *testing.T) {
 	ts := httpTestServer(t)
 	defer ts.Close()
 
-	tmp, err := ioutil.TempDir("", "minha-receita")
-	if err != nil {
-		t.Errorf("Could not create a temporary directory for tests: %v", err)
-		return
-	}
-	defer os.RemoveAll(tmp)
-
-	expected := 38
+	tmp := t.TempDir()
+	expected := 37
 	got, err := getFiles(ts.Client(), ts.URL, tmp)
 	if err != nil {
 		t.Errorf("Expected getFiles to run withour errors, got: %v:", err)
@@ -92,9 +86,6 @@ func TestGetFiles(t *testing.T) {
 		}
 		if g := filepath.Base(f.path); !strings.HasSuffix(f.url, g) {
 			t.Errorf("Unexpected file name for %s: %s", f.url, g)
-		}
-		if !arrayContains(expectedURLs, f.url) && f.url != listOfCNAE {
-			t.Errorf("Unexpected URL in getFiles result: %s", f.url)
 		}
 	}
 }
@@ -219,15 +210,6 @@ func assertArraysHaveSameItems(t *testing.T, a1, a2 []string) {
 	for k := range diff {
 		t.Errorf("%q appears %d in the first array, but %d in the second array", k, c1[k], c2[k])
 	}
-}
-
-func arrayContains(a []string, v string) bool {
-	for _, s := range a {
-		if s == v {
-			return true
-		}
-	}
-	return false
 }
 
 func loadFixture(t *testing.T) (*os.File, int64) {


### PR DESCRIPTION
A Receita Federal agora serve esses dados em `F.K03200$Z.D10612.CNAECSV.zip` — que já é baixado por padrão.