### PR TITLE
Adiciona documentação do PostgreSQL via Docker 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,43 @@
 # Contribuindo com a Minha Receita
 
-Escreva testes e rode os testes.
-
-Se for utilizar Docker,  copie o arquivo `.env.sample` como `.env` — e ajuste, se necessário. E lembre-se de reconstruir os _containers_ para saber se está tudo certo antes de fazer um _commit_.
+Escreva testes e rode os testes, use autoformatação e _linter_:
 
 ```console
 $ gofmt ./
+$ golint .
 $ go test ./...
-$ docker-compose build
 ```
+
+Os testes requerem um banco de dados de teste, com acesso configurado em `TEST_POSTGRES_URI` como no exemplo em `.env`.
+
+## Docker
+
+### Apenas para o banco de dados
+
+Caso queira utilizar o Docker apenas para subir o banco de dados, utilize:
+
+```console
+$ docker-compose up -d postgres
+```
+
+Existe também um banco de dados para teste, que não persiste dados:
+
+```console
+$ docker-compose up -d postgres_test
+```
+
+As configurações padrão desses bancos são:
+
+| Serviço | Ambiente | Variável de ambiente | Valor |
+|---|---|---|---|
+| `postgrtes` | Desenvolvimento | `POSTGRES_URI` | `postgres://minhareceita:minhareceita@localhost:5432/minhareceita?sslmode=disable` |
+| `postgres_test` | Testes | `TEST_POSTGRES_URI` | `postgres://minhareceita:minhareceita@localhost:5555/minhareceita?sslmode=disable` |
+
+### Rodando o projeto todo com Docker
+
+Se for utilizar Docker para rodar o projeto todo,  copie o arquivo `.env.sample` como `.env` — e ajuste, se necessário.
+
+O banco de dados de sua escolha (padrão, que persiste dados; ou de testes, que não persiste dados) tem que ser [iniciado isoladamente](#apenas-para-o-banco-de-dados).
 
 ## Arquitetura
 

--- a/docs/servidor.md
+++ b/docs/servidor.md
@@ -1,5 +1,17 @@
 # Servidor
 
+## Banco de dados
+
+O projeto requer um banco de dados PostgreSQL e suas credenciais devem estar em uma variável de ambiente chamada `POSTGRES_URI`.
+
+Caso deseje usar o Docker Compose do projeto para subir uma instância do banco de dados:
+
+```console
+$ docker-compose up -d postgres
+```
+
+E configure o acesso com `postgres://minhareceita:minhareceita@localhost:5432/minhareceita?sslmode=disable`.
+
 ## Download dos dados
 
 O comando `download` faz o download dos arquivos necessários para alimentar o banco de dados. Na sequência, o comando `transform` transforma os arquivos para o formato JSON. Ambos aceitam o argumento `--directory` (ou `-d`) com um diretório onde encontrar os dados (o padrão é `data/`).


### PR DESCRIPTION
Depois da #71, o banco de dados não sobe mais “automagicamente” pois devemos escolher se queremos um banco para desenvolvimento (que persite dados) ou para testes apenas (que não persiste dados). Esse PR adiciona informações relevantes sobre esse contexto à documentação.

(Mergear apenas depois do #71 se juntar à _branch_ `dev`.)