### PR TITLE
Cria CSV para o comando `copy` do PostgreSQL

### DIFF
--- a/csv/csv.go
+++ b/csv/csv.go
@@ -1,4 +1,147 @@
+// Package csv handles the creation of a CSV file for PostgreSQL copy command.
 package csv
 
-// Path is the name of CSV file ready for PostgresSQL copy command.
-const Path = "cnpj.csv.gz"
+import (
+	"compress/gzip"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/cuducos/minha-receita/transform"
+	"github.com/schollz/progressbar/v3"
+)
+
+const (
+	// Path is the name of CSV file ready for PostgresSQL copy command.
+	Path = "cnpj.csv.gz"
+
+	// IDFieldName is the name of the primary key column in PostgreSQL, i.e. the CNPJ.
+	IDFieldName = "id"
+
+	// JSONFieldName is the name of the column in PostgreSQL with the JSON content.
+	JSONFieldName = "json"
+
+	// MaxReadDirEntries is the maximum number of files or directories
+	// returned at each attempt to read a directory.
+	MaxReadDirEntries = 32
+)
+
+type task struct {
+	dir    string
+	rows   chan []string
+	errors chan error
+	wg     *sync.WaitGroup
+}
+
+func (t *task) readDir(dir string) {
+	if t.dir != dir { // we keep track of recursive calls in a WaitGroup
+		defer t.wg.Done()
+	} else { // wait for the recursive calls to finish and close the channel
+		defer func(t *task) {
+			t.wg.Wait()
+			close(t.rows)
+			close(t.errors)
+		}(t)
+	}
+
+	d, err := os.Open(dir)
+	if err != nil {
+		t.errors <- fmt.Errorf("error opening directory %s: %w", t.dir, err)
+		return
+	}
+	defer d.Close()
+
+	for {
+		ls, err := d.Readdirnames(MaxReadDirEntries)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.errors <- fmt.Errorf("error reading diretcory %s: %w", dir, err)
+			return
+		}
+		for _, p := range ls {
+			p := filepath.Join(d.Name(), p)
+			f, err := os.Open(p)
+			if err != nil {
+				t.errors <- fmt.Errorf("error opening path %s: %w", p, err)
+				continue
+			}
+			s, err := f.Stat()
+			if err != nil {
+				t.errors <- fmt.Errorf("error getting stat for %s: %w", p, err)
+				continue
+			}
+			if s.IsDir() {
+				t.wg.Add(1)
+				go t.readDir(p)
+				continue
+			}
+			if !strings.HasSuffix(p, ".json") {
+				continue
+			}
+			n, err := transform.CNPJForPath(p)
+			if err != nil {
+				log.Output(2, fmt.Sprintf("Invalid JSON file path for a CNPJ %s", p))
+				continue
+			}
+			j, err := ioutil.ReadFile(p)
+			if err != nil {
+				t.errors <- fmt.Errorf("error reading %s: %w", p, err)
+				continue
+			}
+			t.rows <- []string{n, strings.TrimSpace(string(j))}
+		}
+	}
+	return
+}
+
+func newTask(dir string) task {
+	var wg sync.WaitGroup
+	return task{
+		dir:    dir,
+		rows:   make(chan []string),
+		errors: make(chan error),
+		wg:     &wg,
+	}
+}
+
+// CreateCSV creates a GZipped CSV file for PostgreSQ copy command.
+func CreateCSV(dir string) error {
+	p := filepath.Join(dir, Path)
+	f, err := os.Create(p)
+	if err != nil {
+		return fmt.Errorf("error while creating the CSV file %s: %w", p, err)
+	}
+	defer f.Close()
+
+	z := gzip.NewWriter(f)
+	defer z.Close()
+
+	w := csv.NewWriter(z)
+	w.Write([]string{IDFieldName, JSONFieldName})
+	defer w.Flush()
+
+	t := newTask(dir)
+	go t.readDir(dir)
+
+	bar := progressbar.Default(-1, fmt.Sprintf("Writing CNPJ data to %s", p))
+	for {
+		select {
+		case err := <-t.errors:
+			return fmt.Errorf("error running create csv: %w", err)
+		case r, ok := <-t.rows:
+			w.Write(r)
+			bar.Add(1)
+			if !ok {
+				return nil
+			}
+		}
+	}
+}

--- a/csv/csv_test.go
+++ b/csv/csv_test.go
@@ -1,0 +1,49 @@
+package csv
+
+import (
+	"compress/gzip"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCreateCSV(t *testing.T) {
+	tmp := t.TempDir()
+	d := filepath.Join(tmp, "33", "683", "111")
+	if err := os.MkdirAll(d, 0755); err != nil {
+		t.Errorf("expected no error creating %s, got %s", d, err)
+	}
+	p := filepath.Join(d, "000280.json")
+	if err := ioutil.WriteFile(p, []byte(`{"answer":42}`), 0755); err != nil {
+		t.Errorf("expected no error creating %s, got %s", p, err)
+	}
+
+	if err := CreateCSV(tmp); err != nil {
+		t.Errorf("expected no error creating csv, got %s", err)
+	}
+
+	f, err := os.Open(filepath.Join(tmp, Path))
+	if err != nil {
+		t.Errorf("expected no error opening csv file, got %s", err)
+	}
+	defer f.Close()
+
+	r, err := gzip.NewReader(f)
+	if err != nil {
+		t.Errorf("expected no errors unarchiving the csv file, got %s", err)
+	}
+	defer r.Close()
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Errorf("expected no errors reading the csv file, got %s", err)
+	}
+
+	got := strings.TrimSpace(string(b))
+	expected := "id,json\n33683111000280,\"{\"\"answer\"\":42}\""
+	if string(got) != expected {
+		t.Errorf("\nexpected:\n\n%s\n\ngot:\n\n%s\n\n", expected, got)
+	}
+}

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -17,15 +17,7 @@ import (
 	"github.com/go-pg/pg/v10"
 )
 
-const (
-	tableName = "cnpj"
-
-	// IDFieldName is the name of the primary key column in PostgreSQL, i.e. the CNPJ.
-	IDFieldName = "id"
-
-	// JSONFieldName is the name of the column in PostgreSQL with the JSON content.
-	JSONFieldName = "json"
-)
+const tableName = "cnpj"
 
 //go:embed postgres
 var sql embed.FS
@@ -146,7 +138,7 @@ func NewPostgreSQL(u, s string) (PostgreSQL, error) {
 	if err != nil {
 		return PostgreSQL{}, fmt.Errorf("unable to parse postgres uri %s: %w", u, err)
 	}
-	p := PostgreSQL{pg.Connect(opt), u, s, tableName, IDFieldName, JSONFieldName}
+	p := PostgreSQL{pg.Connect(opt), u, s, tableName, csv.IDFieldName, csv.JSONFieldName}
 	if err := p.conn.Ping(context.Background()); err != nil {
 		return PostgreSQL{}, fmt.Errorf("could not connect to postgres: %w", err)
 	}

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 )
 
-const maxFilesOpened = 512 // TODO how to optimize this number?
+// MaxFilesOpened is the maximum number of files opened at the same time.
+const MaxFilesOpened = 512 // TODO how to optimize this number?
 
 // Transform the downloaded files for company venues creating a JSON file per CNPJ
 func Transform(srcDir, outDir string) error {
@@ -12,7 +13,7 @@ func Transform(srcDir, outDir string) error {
 	if err != nil {
 		return fmt.Errorf("error creating new task for venues in %s: %w", srcDir, err)
 	}
-	if err := t.run(maxFilesOpened); err != nil {
+	if err := t.run(MaxFilesOpened); err != nil {
 		return err
 	}
 	return addPartners(srcDir, outDir, t.lookups)


### PR DESCRIPTION
Esse PR, dada a estrutura de diretórios e arquivos JSON para cada CNPJ, cria um CSV pronto para o comando `copy` do PostgreSQL (utilizado em `db.ImportData`).
 
A ser mergeado depois do #71 para resolver conflitos e aproveitar coisas de lá, como `db.IDFieldName` e `db.JSONFieldName`.