### PR TITLE
Refatora `cmd/cmd.go`

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -116,20 +116,13 @@ func (app api) healthHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // Serve spins up the HTTP server.
-func Serve(db database) {
-	port := os.Getenv("PORT")
-	if port == "" {
-		log.Output(2, "No PORT environment variable found, using 8000.")
-		port = ":8000"
+func Serve(db database, p, n string) {
+	if !strings.HasPrefix(p, ":") {
+		p = ":" + p
 	}
-
-	if !strings.HasPrefix(port, ":") {
-		port = ":" + port
-	}
-
-	nr := newRelicApp()
+	nr := newRelicApp(n)
 	app := api{db: db}
 	http.HandleFunc(newRelicHandle(nr, "/", app.companyHandler))
 	http.HandleFunc(newRelicHandle(nr, "/healthz", app.healthHandler))
-	log.Fatal(http.ListenAndServe(port, nil))
+	log.Fatal(http.ListenAndServe(p, nil))
 }

--- a/api/new_relic.go
+++ b/api/new_relic.go
@@ -2,17 +2,14 @@ package api
 
 import (
 	"net/http"
-	"os"
 
 	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
-func newRelicApp() *newrelic.Application {
-	k := os.Getenv("NEW_RELIC_LICENSE_KEY")
+func newRelicApp(k string) *newrelic.Application {
 	if k == "" {
 		return nil
 	}
-
 	app, err := newrelic.NewApplication(
 		newrelic.ConfigAppName("Minha Receita"),
 		newrelic.ConfigLicense(k),

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,19 +19,11 @@ const help = `Minha Receita.
 Toolbox to manage Minha Receita, including tools to handle extract, transform
 and load data, manage the PostgreSQL instance, and to spin up the web server.
 
-Requires a POSTGRES_URI environment variable with PostgreSQL credentials.
-
-An optional POSTGRES_SCHEMA environment variable can be user to set a different
-schema than “public” (which is the default).
-
 See --help for more details.
 `
 
 const apiHelper = `
 Starts the web API.
-
-The port used is 8000, unless an environment variable PORT points to a
-different number.
 
 Using GODEBUG environment variable changes the HTTP server verbosity (for
 example: http2debug=1 is verbose and http2debug=2 is more verbose, as in
@@ -51,14 +43,20 @@ const transformHelper = `
 Convert ths CSV files from the Federal Revenue for venues (ESTABELE group of
 files) into a a group of JSON files, 1 per CNPJ.`
 
+const defaultPort = "8000"
+
 var (
-	dir      string
-	urlsOnly bool
-	timeout  string
+	outDir         string
+	srcDir         string
+	urlsOnly       bool
+	timeout        string
+	databaseURI    string
+	postgresSchema string
+	port           string
+	newRelic       string
 )
 
-func assertDirExists() error {
-	var err error
+func assertDirExists(dir string) error {
 	i, err := os.Stat(dir)
 	if os.IsNotExist(err) {
 		return fmt.Errorf("directory %s does not exist", dir)
@@ -66,21 +64,21 @@ func assertDirExists() error {
 	if err != nil {
 		return err
 	}
-
 	if !i.Mode().IsDir() {
 		return fmt.Errorf("%s is not a directory", dir)
 	}
-
 	return nil
 }
 
-func loadDatabaseURI() string {
+func loadDatabaseURI() (string, error) {
+	if databaseURI != "" {
+		return databaseURI, nil
+	}
 	u := os.Getenv("POSTGRES_URI")
 	if u == "" {
-		fmt.Fprintf(os.Stderr, "Please, set an environmental variable POSTGRES_URI with the credentials for the PostgreSQL database.\n")
-		os.Exit(1)
+		return "", fmt.Errorf("could not find a database URI, pass it as a flag or set POSTGRES_URI environment variable with the credentials for a PostgreSQL database")
 	}
-	return u
+	return u, nil
 }
 
 var rootCmd = &cobra.Command{
@@ -94,11 +92,24 @@ var apiCmd = &cobra.Command{
 	Short: "Spins up the web API",
 	Long:  apiHelper,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		pg, err := db.NewPostgreSQL(loadDatabaseURI())
+		u, err := loadDatabaseURI()
 		if err != nil {
 			return err
 		}
-		api.Serve(&pg)
+		pg, err := db.NewPostgreSQL(u, postgresSchema)
+		if err != nil {
+			return err
+		}
+		if port == "" {
+			port = os.Getenv("PORT")
+		}
+		if port == "" {
+			port = defaultPort
+		}
+		if newRelic == "" {
+			newRelic = os.Getenv("NEW_RELIC_LICENSE_KEY")
+		}
+		api.Serve(&pg, port, newRelic)
 		return nil
 	},
 }
@@ -108,14 +119,14 @@ var downloadCmd = &cobra.Command{
 	Short: "Downloads the required ZIP and Excel files",
 	Long:  downloadHelper,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if err := assertDirExists(); err != nil {
+		if err := assertDirExists(srcDir); err != nil {
 			return err
 		}
 		dur, err := time.ParseDuration(timeout)
 		if err != nil {
 			return err
 		}
-		return download.Download(dir, dur, urlsOnly)
+		return download.Download(srcDir, dur, urlsOnly)
 	},
 }
 
@@ -124,19 +135,25 @@ var transformCmd = &cobra.Command{
 	Short: "Transforms the CSV files into a group of JSON files, 1 per CNPJ",
 	Long:  transformHelper,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if err := assertDirExists(); err != nil {
+		if err := assertDirExists(srcDir); err != nil {
 			return err
 		}
-		return transform.Transform(dir)
+		if err := assertDirExists(outDir); err != nil {
+			return err
+		}
+		return transform.Transform(srcDir, outDir)
 	},
 }
 
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Creates the required tables in PostgreSQL",
-	Long:  "Creates the required tables in PostgreSQL, using the environment variable POSTGRES_URI to connect to the database.",
 	RunE: func(_ *cobra.Command, _ []string) error {
-		pg, err := db.NewPostgreSQL(loadDatabaseURI())
+		u, err := loadDatabaseURI()
+		if err != nil {
+			return err
+		}
+		pg, err := db.NewPostgreSQL(u, postgresSchema)
 		if err != nil {
 			return err
 		}
@@ -148,9 +165,12 @@ var createCmd = &cobra.Command{
 var dropCmd = &cobra.Command{
 	Use:   "drop",
 	Short: "Drops the tables in PostgreSQL",
-	Long:  "Drops the tables in PostgreSQL, using the environment variable POSTGRES_URI to connect to the database.",
 	RunE: func(_ *cobra.Command, _ []string) error {
-		pg, err := db.NewPostgreSQL(loadDatabaseURI())
+		u, err := loadDatabaseURI()
+		if err != nil {
+			return err
+		}
+		pg, err := db.NewPostgreSQL(u, postgresSchema)
 		if err != nil {
 			return err
 		}
@@ -161,25 +181,51 @@ var dropCmd = &cobra.Command{
 
 var importCmd = &cobra.Command{
 	Use:   "import",
-	Short: "Imports the generated CSV and the Excel files into PostgreSQL",
-	Long:  "Reads the compressed CSV and Excel files from a directory and copy their contents to the PostgreSQL tables, using the environment variable POSTGRES_URI to connect to the database.",
+	Short: "Imports the generated CSV into PostgreSQL",
 	RunE: func(_ *cobra.Command, _ []string) error {
-		assertDirExists()
-		pg, err := db.NewPostgreSQL(loadDatabaseURI())
+		if err := assertDirExists(outDir); err != nil {
+			return err
+		}
+		u, err := loadDatabaseURI()
+		if err != nil {
+			return err
+		}
+		pg, err := db.NewPostgreSQL(u, postgresSchema)
 		if err != nil {
 			return err
 		}
 		defer pg.Close()
-		return pg.ImportData(dir)
+		return pg.ImportData(outDir)
 	},
 }
 
 // CLI returns the root command from Cobra CLI tool.
 func CLI() *cobra.Command {
+	apiCmd.Flags().StringVarP(
+		&port,
+		"port",
+		"p",
+		"",
+		fmt.Sprintf("web server port (default PORT environment variable or %s)", defaultPort),
+	)
+	apiCmd.Flags().StringVarP(
+		&newRelic,
+		"new-relic-key",
+		"n",
+		"",
+		"New Relic license key (deafult NEW_RELIC_LICENSE_KEY environment variable)",
+	)
 	downloadCmd.Flags().BoolVarP(&urlsOnly, "urls-only", "u", false, "only list the URLs")
 	downloadCmd.Flags().StringVarP(&timeout, "timeout", "t", "15m0s", "timeout for each download")
-	for _, c := range []*cobra.Command{downloadCmd, transformCmd, importCmd} {
-		c.Flags().StringVarP(&dir, "directory", "d", "data", "data directory")
+	for _, c := range []*cobra.Command{downloadCmd, transformCmd} {
+		c.Flags().StringVarP(&srcDir, "source-directory", "s", "data", "directory of original CSV files")
+	}
+	for _, c := range []*cobra.Command{transformCmd, importCmd} {
+		c.Flags().StringVarP(&srcDir, "output-directory", "o", "data", "directory of generated JSON & CSV files")
+	}
+	for _, c := range []*cobra.Command{createCmd, dropCmd, importCmd, apiCmd} {
+		c.Flags().StringVarP(&databaseURI, "database-uri", "d", "", "PostgreSQL URI (default POSTGRES_URI environment variable)")
+		c.Flags().StringVarP(&postgresSchema, "postgres-schema", "s", "public", "PostgreSQL schema")
 	}
 	for _, c := range []*cobra.Command{apiCmd, downloadCmd, transformCmd, createCmd, dropCmd, importCmd} {
 		rootCmd.AddCommand(c)

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -141,15 +141,10 @@ func (p *PostgreSQL) ImportData(dir string) error {
 }
 
 // NewPostgreSQL creates a new PostgreSQL connection and ping it to make sure it works.
-func NewPostgreSQL(u string) (PostgreSQL, error) {
+func NewPostgreSQL(u, s string) (PostgreSQL, error) {
 	opt, err := pg.ParseURL(u)
 	if err != nil {
 		return PostgreSQL{}, fmt.Errorf("unable to parse postgres uri %s: %w", u, err)
-	}
-	s := os.Getenv("POSTGRES_SCHEMA")
-	if s == "" {
-		log.Output(2, "No POSTGRES_SCHEMA environment variable found, using public.")
-		s = "public"
 	}
 	p := PostgreSQL{pg.Connect(opt), u, s, tableName, IDFieldName, JSONFieldName}
 	if err := p.conn.Ping(context.Background()); err != nil {

--- a/db/postgres_test.go
+++ b/db/postgres_test.go
@@ -12,7 +12,7 @@ func TestPostgresDB(t *testing.T) {
 		t.Errorf("expected a posgres uri at TEST_POSTGRES_URI, found nothing")
 		return
 	}
-	pg, err := NewPostgreSQL(u)
+	pg, err := NewPostgreSQL(u, "public")
 	if err != nil {
 		t.Errorf("expected no error connecting to postgres, got %s", err)
 		return

--- a/transform/partners.go
+++ b/transform/partners.go
@@ -131,7 +131,7 @@ func addPartner(l *lookups, dir string, r []string) error {
 }
 
 type partnersTask struct {
-	dir     string
+	outDir  string
 	lookups *lookups
 	queues  []chan []string
 	success chan struct{}
@@ -141,7 +141,7 @@ type partnersTask struct {
 
 func (t *partnersTask) consumeShard(n int) {
 	for r := range t.queues[n] {
-		if err := addPartner(t.lookups, t.dir, r); err != nil {
+		if err := addPartner(t.lookups, t.outDir, r); err != nil {
 			t.errors <- fmt.Errorf("error processing partner %v: %w", r, err)
 			continue
 		}
@@ -149,15 +149,15 @@ func (t *partnersTask) consumeShard(n int) {
 	}
 }
 
-func addPartners(dir string, l *lookups) error {
-	s, err := newSource(partners, dir)
+func addPartners(srcDir, outDir string, l *lookups) error {
+	s, err := newSource(partners, srcDir)
 	if err != nil {
 		return fmt.Errorf("error creating source for partners: %w", err)
 	}
 	defer s.close()
 
 	t := partnersTask{
-		dir:     dir,
+		outDir:  outDir,
 		lookups: l,
 		success: make(chan struct{}),
 		errors:  make(chan error),

--- a/transform/partners_test.go
+++ b/transform/partners_test.go
@@ -27,7 +27,7 @@ func TestAddPartners(t *testing.T) {
 		t.Errorf("expected no error creating look up tables, got %s", err)
 		return
 	}
-	if err := addPartners(d, &l); err != nil {
+	if err := addPartners(d, d, &l); err != nil {
 		t.Errorf("expected no errors adding partners, got %s", err)
 		return
 	}

--- a/transform/task_test.go
+++ b/transform/task_test.go
@@ -20,7 +20,7 @@ func TestTaskRun(t *testing.T) {
 			copyFile(f, d)
 		}
 	}
-	p, err := newTask(d, venues)
+	p, err := newTask(d, d)
 	if err != nil {
 		t.Errorf("expected no error creating task, got %s", err)
 	}

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -7,13 +7,13 @@ import (
 const maxFilesOpened = 512 // TODO how to optimize this number?
 
 // Transform the downloaded files for company venues creating a JSON file per CNPJ
-func Transform(dir string) error {
-	t, err := newTask(dir, venues)
+func Transform(srcDir, outDir string) error {
+	t, err := newTask(srcDir, outDir)
 	if err != nil {
-		return fmt.Errorf("error creating new task for %s in %s: %w", string(venues), dir, err)
+		return fmt.Errorf("error creating new task for venues in %s: %w", srcDir, err)
 	}
 	if err := t.run(maxFilesOpened); err != nil {
 		return err
 	}
-	return addPartners(dir, t.lookups)
+	return addPartners(srcDir, outDir, t.lookups)
 }


### PR DESCRIPTION
Como descrito na #81:
- evita o `os.Exit`
- implementa diretórios diferentes para leitura e escrita
- implementa configurações de banco de dados e API