### PR TITLE
Remove o comando "go test" do Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ADD db/ ./db/
 ADD download/ ./download/
 ADD testdata/ ./testdata/
 ADD transform/ ./transform/
-RUN go get && go test ./... && go build -o /usr/bin/minha-receita
+RUN go get && go build -o /usr/bin/minha-receita
 
 FROM debian:bullseye-slim
 RUN apt-get update && \


### PR DESCRIPTION
Seguindo a issue #96, remove o comando `go test` do `Dockerfile` que impede o `docker-compose build` finalizar sem erros.