### PR TITLE
Corrige erro de envio de mensagem no canal fechado

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 .env
-.ipynb_checkpoints/
 bin/
 data/
 site/
 ~/data/.gitkeep
-minha-receita

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ data/
 site/
 ~/data/.gitkeep
 minha-receita
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ data/
 site/
 ~/data/.gitkeep
 minha-receita
+.DS_Store

--- a/transform/venues.go
+++ b/transform/venues.go
@@ -94,6 +94,9 @@ func (t *venuesTask) consumeRows() {
 			b = []company{}
 		}
 	}
+	if atomic.LoadInt32(&t.shutdown) == 1 { // check if must continue.
+		return
+	}
 	// send the remaining items in the batch
 	n, err := saveBatch(t.db, b)
 	if err != nil { // initiate graceful shutdown.


### PR DESCRIPTION
Aproveitando para também adicionar arquivos .DS_Store ao .gitignore. Esses arquivos são criados automaticamente sempre que usamos o finder para acessar diretórios.