### PR TITLE
Verifica se `psql` existe antes de iniciar o processamento

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -160,10 +160,15 @@ var transformCmd = &cobra.Command{
 		if err := assertDirExists(); err != nil {
 			return err
 		}
+		if err := db.AssertPostgresCLIExists(); err != nil {
+			return err
+		}
+
 		u, err := loadDatabaseURI()
 		if err != nil {
 			return err
 		}
+
 		pg, err := db.NewPostgreSQL(u, postgresSchema)
 		if err != nil {
 			return err

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"embed"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"log"
 	"os/exec"
@@ -91,6 +92,16 @@ func (p *PostgreSQL) UpdateCompany(id, json string) error {
 	}
 	if _, err := p.conn.Exec(sql, json, id); err != nil {
 		return fmt.Errorf("error updating record %s: %s\n%w", cnpj.Mask(id), sql, err)
+	}
+	return nil
+}
+
+// AssertPostgresCLIExists searches for the PostgreSQL executable (psql) in the
+// environment's PATH. It will return an error if no executable is found.
+func AssertPostgresCLIExists() error {
+	_, err := exec.LookPath("psql")
+	if err != nil {
+		return errors.New("postgres client (psql) not installed or not in PATH")
 	}
 	return nil
 }


### PR DESCRIPTION
Tentei deixar o mais simples possível. 

Encontrei duas abordagens para a checagem, usando o **exec.LookPath** ou o **exec.Command**, mas com o Command precisaria abrir um shell para conseguir rodar comandos nativos para checar se existe o psql (rodaria o `command -v psql`), então achei mais simples usar o LookPath.

Estou aberto para corrigir algo. :smile: 