### PR TITLE
Creates Docker image to easily update prodution

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,0 +1,8 @@
+# build minha-receita bin
+FROM ghcr.io/cuducos/minha-receita:main
+WORKDIR /minha-receita
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends screen && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+CMD ["./update.sh"]

--- a/contrib/update.sh
+++ b/contrib/update.sh
@@ -1,0 +1,21 @@
+# Running this script requires DATA_URL and POSTGRES_URI envvars. `DATA_URL`
+# should be a `.tar` file with the downloaded files (no directories).
+
+set -e
+
+echo '==> Starting a Screen session named minha-receita…'
+screen -r minha-receita
+
+echo "==> Downloading $DATA_URL…"
+mkdir data
+curl -L $DATA_URL > data/data.tar
+
+echo "==> Unarchiving $DATA_URL…"
+tar -xvf data/data.tar
+rm data.tar
+
+echo '==> Checking files…'
+minha-receita check
+
+echo '==> Starting the ETL…'
+minha-receita transform --clean-up


### PR DESCRIPTION

Esse PR é um rascunho para algumas ferramentas que ajudem a atualizar o banco de dados de produção: #132

Ele depende da [recém criada imagem Docker](https://docs.minhareceita.org/instalacao/#imagem-docker).

Com ela, criamos uma segunda imagem Docker para ser utilizada para a atualização (uma que tem o Screen instalado), e depois reproduzi os passos no `update.sh` — que ainda não testei.

Na minha cabeça, o ideal seria criar uma máquina virtual a partir dessa imagem, e criar as variáveis de ambiente:
* `DATA_URL`: um `.tar` com os arquivos baixados (por exemplo: `https://www.dropbox.com/s/ho3wi9njjfxf7qj/2022-06-15.tar`)
* `POSTGRES_URI`: com os dados de acesso ao bando no formato `postgres://…`

---

Closes #132