### PR TITLE
Remove bug e aumenta o número de shards

### DIFF
--- a/transform/shard.go
+++ b/transform/shard.go
@@ -7,35 +7,18 @@ import (
 	"strconv"
 )
 
-const numOfShards = 64
+const numOfShards = 256
 
 // shards the base of a CNPJ (first 8 digits) to a number between 0 (included)
-// and 16 (not included). It takes the first two digits of the hex digest of
-// the base CNPJ MD5 hash. It multiplies the first of these digits by 1, 2, 3
-// or 4 depending on the second of thsse digits (1 if the second digit is below
-// 4 and so on).
+// and 256 (not included). It takes the first two digits of the hex digest of
+// the base CNPJ MD5 hash and converts them to an integer number.
 func shard(n string) (int, error) {
 	c := md5.Sum([]byte(n[0:8]))
 	h := hex.EncodeToString(c[:])
-	h1 := h[:1]
-	h2 := h[1:2]
-	d1, err := strconv.ParseInt(h1, 16, 64)
+	d := h[:2]
+	i, err := strconv.ParseInt(d, 16, 64)
 	if err != nil {
-		return 0, fmt.Errorf("error parsing the shard from hex %s for %s: %w", h1, n, err)
+		return 0, fmt.Errorf("error parsing the shard from hex %s for %s: %w", d, n, err)
 	}
-	d2, err := strconv.ParseInt(h2, 16, 64)
-	if err != nil {
-		return 0, fmt.Errorf("error parsing the shard from hex %s for %s: %w", h2, n, err)
-	}
-	var m int
-	if d2 < 4 {
-		m = 1
-	} else if d2 < 8 {
-		m = 2
-	} else if m < 12 {
-		m = 3
-	} else {
-		m = 4
-	}
-	return int(d1) * m, nil
+	return int(i), nil
 }


### PR DESCRIPTION
Remove bug (`else if m < 12 ` quando deveria ser `else if d2 < 12`) e aumenta o número de _shards_.

Todos os números de consumo de CPU e memória estão baixos, tanto na máquina produzindo os dados, quanto no banco de dados. Então podemos aumentar : )