### PR TITLE
Adiciona página sobre qualidade de dados públicos na documentação

### DIFF
--- a/docs/sobre-os-dados.md
+++ b/docs/sobre-os-dados.md
@@ -1,0 +1,16 @@
+# Sobre os dados
+
+
+Os dados servidos pela API estão disponibilizados tal como foram publicados pela Receita Federal, salvo as [exceções feitas para em prol da privacidade](/servidor/#questoes-de-privacidade).
+
+Devido à experiência utilizando dados públicos, é bom lembrar que esses dados _podem_ conter problemas como desatualização, incorreção, incompletude ou inconsistência, por exemplo. Como essa API é apenas uma fonte secundária para os dados, não temos como identificar ou corrigir esses problemas, então tenha isso em mente ao consultar o _Minha Receita_.
+
+Em caso de problemas na base de dados, faça uma manifestação oficial via protocolo no [Fala.BR](https://falabr.cgu.gov.br/publico/Manifestacao/SelecionarTipoManifestacao.aspx) solicitando a correção.
+
+Caso queira, [abra uma _issue_ no GithHub](https://github.com/cuducos/minha-receita/issues) quando localizar algum problema nos dados, indicando:
+
+1. qual o problema localizado
+1. quando localizou
+1. como localizou este problema
+
+Isso permite que a gente junte casos para alertar formalmente a Receita Federal do Brasil sobre a questão, para que eles tomem as medidas necessárias para corrigir os dados.


### PR DESCRIPTION
O que acha, @jedibruno? Dei uma editada na sua sugestão da #143. A pré-visualização está [aqui](https://deploy-preview-144--minhareceita.netlify.app/sobre-os-dados/), mas tem essa carinha se quiser economizar um clique:

![image](https://user-images.githubusercontent.com/4732915/189231157-86b5cb9f-1f6c-4956-adbe-c803e2d21eb6.png)
