### PR TITLE
Adiciona índice e remove duplicados após carregar os dados

### DIFF
--- a/db/postgres.go
+++ b/db/postgres.go
@@ -134,6 +134,16 @@ func (p *PostgreSQL) CreateCompanies(batch [][]string) error {
 	return nil
 }
 
+// CreateIndex runs after all the data is creates. It drops duplicates and
+// create a primary key on the ID field.
+func (p *PostgreSQL) CreateIndex() error {
+	log.Output(2, "Creating indexess…")
+	if _, err := p.conn.Exec(p.sql["create_index.sql"]); err != nil {
+		return fmt.Errorf("error creating index with: %s\n%w", p.sql["create_index.sql"], err)
+	}
+	return nil
+}
+
 // Returns the minimum and maximum CNPJ possible given a base CNPJ.
 func rangeFor(base string) (int64, int64, error) {
 	n, err := strconv.ParseInt(base, 10, 64)

--- a/db/postgres/create.sql
+++ b/db/postgres/create.sql
@@ -1,5 +1,5 @@
 CREATE UNLOGGED TABLE IF NOT EXISTS {{ .CompanyTableFullName }} (
-    {{ .IDFieldName }}   bigint NOT NULL PRIMARY KEY,
+    {{ .IDFieldName }}   bigint NOT NULL,
     {{ .JSONFieldName }} jsonb NOT NULL
 );
 CREATE TABLE IF NOT EXISTS {{ .MetaTableFullName }} (

--- a/db/postgres/create_index.sql
+++ b/db/postgres/create_index.sql
@@ -1,0 +1,20 @@
+CREATE INDEX idx_remove_duplicates ON {{ .CompanyTableFullName }} ({{ .IDFieldName }});
+
+DELETE FROM {{ .CompanyTableFullName }}
+WHERE ctid IN (
+  SELECT ctid
+  FROM (
+    SELECT
+      ctid,
+      row_number() OVER (
+        PARTITION BY ({{ .IDFieldName }})
+        ORDER BY ctid DESC
+      ) AS count
+    FROM {{ .CompanyTableFullName }}
+  ) t
+  WHERE count > 1
+);
+
+DROP INDEX idx_remove_duplicates;
+
+ALTER TABLE cnpj ADD PRIMARY KEY (id);

--- a/db/postgres_test.go
+++ b/db/postgres_test.go
@@ -36,6 +36,12 @@ func TestPostgresDB(t *testing.T) {
 	if err := pg.CreateCompanies([][]string{{id, json}}); err != nil {
 		t.Errorf("expected no error saving a company, got %s", err)
 	}
+	if err := pg.CreateCompanies([][]string{{id, json}}); err != nil {
+		t.Errorf("expected no error saving a duplicated company, got %s", err)
+	}
+	if err := pg.CreateIndex(); err != nil {
+		t.Errorf("expected no error creating index, got %s", err)
+	}
 	got, err := pg.GetCompany("33683111000280")
 	if err != nil {
 		t.Errorf("expected no error getting a company, got %s", err)

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -14,6 +14,7 @@ const BatchSize = 8192
 
 type database interface {
 	CreateCompanies([][]string) error
+	CreateIndex() error
 	UpdateCompanies([][]string) error
 	AddPartners([][]string) error
 	MetaSave(string, string) error

--- a/transform/venues.go
+++ b/transform/venues.go
@@ -138,7 +138,7 @@ func (t *venuesTask) run(m int) error {
 		case n := <-t.saved:
 			t.bar.Add(n)
 			if t.bar.IsFinished() {
-				return nil
+				return t.db.CreateIndex()
 			}
 		}
 	}


### PR DESCRIPTION
Uma outra alternativa para solucionar #146 — ao contrário da #147 ela não deve tornar o processo de importação mais lento, apenas adiciona uma operação ao final da importação.

Como naquele PR, ainda não tive a chance de testar com uma carga grande de dados.