### PR TITLE
Restaura a instalação do ca-certificates no Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,13 @@ FROM debian:bullseye-slim
 LABEL org.opencontainers.image.description="Sua API web para consulta de informações do CNPJ da Receita Federal"
 LABEL org.opencontainers.image.source="https://github.com/cuducos/minha-receita"
 LABEL org.opencontainers.image.title="Minha Receita"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    update-ca-certificates && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /usr/bin/minha-receita /usr/bin/minha-receita
 ENTRYPOINT ["/usr/bin/minha-receita"]
 CMD ["api"]


### PR DESCRIPTION
Ao seguir a documentação e executar `docker-compose run --rm minha-receita download --directory /mnt/data`, o seguinte erro é retornado:

```
error downloading files from the national treasure: error gathering resources for national treasure download: error getting urls: error getting https://www.tesourotransparente.gov.br/ckan/api/3/action/package_show?id=abb968cb-3710-4f85-89cf-875c91b9c7f6: Get "https://www.tesourotransparente.gov.br/ckan/api/3/action/package_show?id=abb968cb-3710-4f85-89cf-875c91b9c7f6": x509: certificate signed by unknown authority
exit code: 1
```

Restaurando a instalação do ca-certificates o problema é resolvido.