### PR TITLE
Adiciona Windows na integração contínua

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,26 +1,27 @@
 name: Tests
+
 on: [push, pull_request]
+
 jobs:
   test:
-    runs-on: ubuntu-latest
-    container: golang:1.19-bullseye
-    services:
-      postgres:
-        image: postgres:14
-        env:
-          POSTGRES_PASSWORD: minhareceita
-          POSTGRES_USER: minhareceita
-          POSTGRES_DB: minhareceita
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+        go: [1.19.x, 1.20.x]
+
+    runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v3
+
+      - uses: ikalnytskyi/action-setup-postgres@v4
+        id: postgres
+
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
-      - run: "go test --race ./..."
+          go-version: ${{ matrix.go }}
+
+      - run: go test --race ./...
         env:
-          TEST_DATABASE_URL: postgres://minhareceita:minhareceita@postgres:5432/minhareceita?sslmode=disable
+          TEST_DATABASE_URL: ${{ steps.postgres.outputs.connection-uri }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,12 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
+      - run: go test ./...
+        if: matrix.os == 'windows-latest'
+        env:
+          TEST_DATABASE_URL: ${{ steps.postgres.outputs.connection-uri }}
+
       - run: go test --race ./...
+        if: matrix.os == 'ubuntu-latest'
         env:
           TEST_DATABASE_URL: ${{ steps.postgres.outputs.connection-uri }}

--- a/check/checksum.go
+++ b/check/checksum.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/schollz/progressbar/v3"
@@ -144,7 +145,7 @@ func CreateChecksum(src string) error {
 	var wg sync.WaitGroup
 
 	for _, f := range ls {
-		if f.IsDir() || f.Name()[0] == '.' {
+		if f.IsDir() || f.Name()[0] == '.' || strings.HasSuffix(f.Name(), ".md5") {
 			continue
 		}
 

--- a/check/checksum_test.go
+++ b/check/checksum_test.go
@@ -2,203 +2,123 @@ package check
 
 import (
 	"crypto/md5"
-	"io"
+	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
-func checksumTestdata(t *testing.T) string {
-	out := t.TempDir()
-	src := filepath.Join("..", "testdata")
-	ls, err := os.ReadDir(src)
-	if err != nil {
-		t.Fatalf("expected no error reading testdata directory, got %s", err)
-	}
-	for _, f := range ls {
-		if filepath.Ext(f.Name()) == ".md5" {
-			continue
+const numTestFiles = 2
+
+var (
+	contents = []string{"This is the contents of file 0", "This is the contents of file 1"}
+	hashes   = []string{"2e68b218b62624b52ee519a42e09f87d", "aa45a469cfb5b5b2ca3094568f0f2039"}
+)
+
+func checksumTestFiles(t *testing.T) string {
+	tmp := t.TempDir()
+	for n := 0; n < numTestFiles; n++ {
+		f := filepath.Join(tmp, fmt.Sprintf("file%d", n))
+		if err := os.WriteFile(f, []byte(contents[n]), 0755); err != nil {
+			t.Fatalf("failed to write file %s: %s", f, err)
 		}
-		func() {
-			r, err := os.Open(filepath.Join(src, f.Name()))
-			if err != nil {
-				t.Fatalf("expected no error opening %s in testdata directory, got %s", f.Name(), err)
-			}
-			defer r.Close()
-
-			w, err := os.Create(filepath.Join(out, f.Name()))
-			if err != nil {
-				t.Fatalf("expected no error creating %s in tmp testdata directory, got %s", f.Name(), err)
-			}
-			defer w.Close()
-
-			if _, err := io.Copy(w, r); err != nil {
-				t.Fatalf("expected no error writing %s, got %s", f.Name(), err)
-			}
-		}()
+		if err := os.WriteFile(f+".md5", []byte(hashes[n]), 0755); err != nil {
+			t.Fatalf("failed to write checksum file %s: %s", f+".md5", err)
+		}
 	}
-	return out
+	return tmp
 }
 
 func TestCreate(t *testing.T) {
-	testCases := []struct {
-		desc     string
-		src      string
-		expected int
-		err      bool
-	}{
-		{
-			"Src directory does not exists",
-			filepath.Join("..", "no-dir"),
-			0,
-			true,
-		},
-		{
-			"Create checksum files",
-			checksumTestdata(t),
-			16,
-			false,
-		},
-	}
+	t.Run("source directory does not exist", func(t *testing.T) {
+		err := CreateChecksum(filepath.Join("..", "directory-does-not-exist"))
+		if err == nil {
+			t.Error("expected error creating checksum files, got nil")
+		}
+	})
 
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			err := CreateChecksum(tc.src)
-
-			if !tc.err && err != nil {
-				t.Errorf("expected no error creating checksum files, got %s", err)
-			}
-
-			ls, err := filepath.Glob(filepath.Join(tc.src, "*.md5"))
-			if err != nil {
-				t.Errorf("expected no error reading dir %s, got %s", tc.src, err)
-			}
-
-			var got int
-			for range ls {
-				got++
-			}
-
-			if got != tc.expected {
-				t.Errorf("expected %d files in the sample directory, got %d", tc.expected, got)
-			}
-		})
-	}
-}
-
-func createChecksumFilesInTestDirectory(t *testing.T) string {
-	out := checksumTestdata(t)
-
-	if err := CreateChecksum(out); err != nil {
-		t.Errorf("expected no error creating testdata checksums, got %s", err)
-	}
-	return out
-}
-
-func testdataWithMissingFiles(t *testing.T) string {
-	src := checksumTestdata(t)
-
-	if err := os.Remove(filepath.Join(src, "Empresas0.zip")); err != nil {
-		t.Errorf("expected no error removing file from testdata, got %s", err)
-	}
-
-	return src
-}
-
-func testdataWithInvalidChecksums(t *testing.T) string {
-	src := createChecksumFilesInTestDirectory(t)
-
-	fh := md5.New()
-	fh.Write([]byte("different data"))
-
-	if err := os.WriteFile(filepath.Join(src, "Empresas0.zip.md5"), fh.Sum(nil), 0755); err != nil {
-		t.Errorf("expected no error creating %s checksum file in directory, got %s", src, err)
-	}
-
-	return src
+	t.Run("create checksum files", func(t *testing.T) {
+		src := checksumTestFiles(t)
+		err := CreateChecksum(src)
+		if err != nil {
+			t.Errorf("expected no error creating checksum files, got %s", err)
+		}
+		ls, err := filepath.Glob(filepath.Join(src, "*.md5"))
+		if err != nil {
+			t.Errorf("expected no error reading dir %s, got %s", src, err)
+		}
+		var got int
+		for range ls {
+			got++
+		}
+		if got != numTestFiles {
+			t.Errorf("expected %d files in the sample directory, got %d: %v", numTestFiles, got, ls)
+		}
+	})
 }
 
 func TestCheck(t *testing.T) {
-	testCases := []struct {
-		desc   string
-		src    string
-		target string
-		err    bool
-	}{
-		{
-			"Src directory has no checksum files",
-			t.TempDir(),
-			t.TempDir(),
-			true,
-		},
-		{
-			"Missing file in target directory",
-			checksumTestdata(t),
-			testdataWithMissingFiles(t),
-			true,
-		},
-		{
-			"Checksums match",
-			createChecksumFilesInTestDirectory(t),
-			createChecksumFilesInTestDirectory(t),
-			false,
-		},
-		{
-			"Checksums does not match",
-			checksumTestdata(t),
-			testdataWithInvalidChecksums(t),
-			true,
-		},
-	}
+	t.Run("source directory does not exist", func(t *testing.T) {
+		tmp := t.TempDir()
+		err := CheckChecksum(tmp, tmp)
+		if err == nil {
+			t.Error("expected error checking checksums, got nil")
+		}
+	})
 
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			err := CheckChecksum(tc.src, tc.target)
-
-			if !tc.err && err != nil {
-				t.Errorf("expected no error checking checksums, got %s", err)
+	t.Run("missing source files", func(t *testing.T) {
+		src := checksumTestFiles(t)
+		out := checksumTestFiles(t)
+		for n := 0; n < numTestFiles; n++ {
+			if err := os.Remove(filepath.Join(src, fmt.Sprintf("file%d.md5", n))); err != nil {
+				t.Fatalf("expected no error removing file from testdata, got %s", err)
 			}
-		})
-	}
+		}
+		err := CheckChecksum(src, out)
+		if err == nil {
+			t.Error("expected error checking checksums, got nil")
+		}
+	})
+
+	t.Run("match", func(t *testing.T) {
+		src := checksumTestFiles(t)
+		out := checksumTestFiles(t)
+		if err := CheckChecksum(src, out); err != nil {
+			t.Errorf("expected no error checking checksums, got %s", err)
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		src := checksumTestFiles(t)
+		out := checksumTestFiles(t)
+		h := md5.New()
+		h.Write([]byte("different data"))
+		if err := os.WriteFile(filepath.Join(src, "file0.md5"), h.Sum(nil), 0755); err != nil {
+			t.Fatalf("expected no error creating %s checksum file in directory, got %s", src, err)
+		}
+		if err := CheckChecksum(src, out); err == nil {
+			t.Error("expected error checking checksums, got nil")
+		}
+	})
 }
 
 func TestChecksumFor(t *testing.T) {
-	_, err := checksumFor(filepath.Join("..", "no-dir", "Estabelecimentos0.zip"))
-
-	if err == nil {
-		t.Error("expected error getting file checksum, got nil")
-	}
-
-	src := filepath.Join("..", "testdata")
-
-	sb, err := checksumFor(filepath.Join(src, "Estabelecimentos0.zip"))
+	src := checksumTestFiles(t)
+	f1 := filepath.Join(src, "file0")
+	h1, err := checksumFor(f1)
 	if err != nil {
-		t.Errorf("expected no error getting file checksum, got %s", err)
+		t.Errorf("expected no error getting %s checksum, got %s", f1, err)
+	}
+	if h1 != hashes[0] {
+		t.Errorf("expected checksum %s for file %s, got %s", hashes[0], f1, h1)
 	}
 
-	tb, err := checksumFor(filepath.Join(src, "response.json"))
+	f2 := filepath.Join(src, "file1")
+	h2, err := checksumFor(f2)
 	if err != nil {
-		t.Errorf("expected no error getting file checksum, got %s", err)
+		t.Errorf("expected no error getting %s checksum, got %s", f2, err)
 	}
-
-	if sb == tb {
-		t.Errorf("expected different checksums for files, but got equal ones")
-	}
-
-	r, err := os.Open(filepath.Join(src, "Estabelecimentos0.zip.md5"))
-	if err != nil {
-		t.Errorf("expected no error opening template checksum file, got %s", err)
-	}
-
-	ssb, err := io.ReadAll(r)
-	if err != nil {
-		t.Errorf("expected no error reading template checksum file, got %s", err)
-	}
-
-	fssb := strings.Trim(string(ssb), "\n")
-
-	if sb != fssb {
-		t.Errorf("expected equal checksums for the same file, but got different ones")
+	if h2 != hashes[1] {
+		t.Errorf("expected checksum %s for file %s, got %s", hashes[1], f2, h2)
 	}
 }

--- a/check/checksum_test.go
+++ b/check/checksum_test.go
@@ -11,33 +11,33 @@ import (
 
 func checksumTestdata(t *testing.T) string {
 	out := t.TempDir()
-
 	src := filepath.Join("..", "testdata")
 	ls, err := os.ReadDir(src)
 	if err != nil {
 		t.Fatalf("expected no error reading testdata directory, got %s", err)
 	}
-
 	for _, f := range ls {
 		if filepath.Ext(f.Name()) == ".md5" {
 			continue
 		}
+		func() {
+			r, err := os.Open(filepath.Join(src, f.Name()))
+			if err != nil {
+				t.Fatalf("expected no error opening %s in testdata directory, got %s", f.Name(), err)
+			}
+			defer r.Close()
 
-		r, err := os.Open(filepath.Join(src, f.Name()))
-		if err != nil {
-			t.Fatalf("expected no error opening %s in testdata directory, got %s", f.Name(), err)
-		}
+			w, err := os.Create(filepath.Join(out, f.Name()))
+			if err != nil {
+				t.Fatalf("expected no error creating %s in tmp testdata directory, got %s", f.Name(), err)
+			}
+			defer w.Close()
 
-		w, err := os.Create(filepath.Join(out, f.Name()))
-		if err != nil {
-			t.Fatalf("expected no error creating %s in tmp testdata directory, got %s", f.Name(), err)
-		}
-
-		if _, err := io.Copy(w, r); err != nil {
-			t.Fatalf("expected no error writing %s, got %s", f.Name(), err)
-		}
+			if _, err := io.Copy(w, r); err != nil {
+				t.Fatalf("expected no error writing %s, got %s", f.Name(), err)
+			}
+		}()
 	}
-
 	return out
 }
 

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -49,7 +49,7 @@ func (p *PostgreSQL) loadTemplates() error {
 		return fmt.Errorf("error looking for templates: %w", err)
 	}
 	for _, f := range ls {
-		t, err := template.ParseFS(sql, filepath.Join("postgres", f.Name()))
+		t, err := template.ParseFS(sql, "postgres/"+f.Name())
 		if err != nil {
 			return fmt.Errorf("error parsing %s template: %w", f, err)
 		}

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -73,6 +73,7 @@ func makeSampleFromZIP(src, outDir string, m int) error {
 	if err != nil {
 		return fmt.Errorf("error opening %s: %w", src, err)
 	}
+	defer r.Close()
 
 	name := filepath.Base(src)
 	base := strings.TrimSuffix(name, filepath.Ext(src))
@@ -141,6 +142,7 @@ func createUpdateAt(src, dir string, dt string) error {
 	if err != nil {
 		return fmt.Errorf("error creating %s: %w", out, err)
 	}
+	defer w.Close()
 	if _, err := io.Copy(w, r); err != nil {
 		return fmt.Errorf("error copying %s to %s: %w", src, out, err)
 	}


### PR DESCRIPTION
* Adiciona Windows como uma matrix de sistemas operacionais para os testes
* Utiliza ema ação externa para subir o PostgreSQL (`services` só funciona com Linux no GitHub Actions)
* Reproduz o erro relatado em #182 
* Resolve o erro utilizando o separator correto para o sistema de arquivos “embedado” do Go
* Resolve erros que a suíte de testes acusou apenas no Windows (arquivos não fechado depois do uso)