### PR TITLE
Reverte mudança de look-up para Badger

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ As configurações padrão desses bancos são:
 
 ### Rodando o projeto todo com Docker
 
-Se for utilizar Docker para rodar o projeto todo,  copie o arquivo `.env.sample` como `.env` — e ajuste, se necessário.
+Se for utilizar Docker para rodar o projeto todo, copie o arquivo `.env.sample` como `.env` — e ajuste, se necessário.
 
 O banco de dados de sua escolha (padrão, que persiste dados; ou de testes, que não persiste dados) tem que ser [iniciado isoladamente](#apenas-para-o-banco-de-dados).
 
@@ -89,16 +89,12 @@ A etapa de transformação dos dados, começa criando armazenamentos de chave e 
 
 A partir daí, cada linha dos `Estabelecimentos*` é lida, enriquecida com esses pares de chave e valor armazenados anteriormente, e então enviada para o banco de dados.
 
-Resumindo:
-
-1. Armazena pares de chave e valor em memória para os dados de: `Cnaes.zip`, `Motivos.zip`, `Municipios.zip`, `Paises.zip`, `Naturezas.zip`, `Qualificacoes.zip` e códigos dos municípios do IBGE
-1. Armazena pares de chave e valor em disco para os dados de:
-    1. `Empresas*` enriquecidas com pares de chave e valor de `Cnaes.zip`, `Motivos.zip`, `Municipios.zip`, `Paises.zip`, `Naturezas.zip`, `Qualificacoes.zip` e códigos dos municípios do IBGE
-    1. `Socios*` enriquecidos com pares de chave e valor de `Qualificacoes.zip`
-    1. `Simples.zip` e enriquecer as linhas do banco de dados com essas informações
-1. Lê os arquivos `Estabelecimentos*`
-1. “Enriquece” cada linha deles com os pares de chave e valor
-1. Persiste essa informação no banco de dados
+| Etapa | Descricão | Armazenamento |
+|:-:|---|---
+| 1 | Armazena pares de chave e valor em memória para os dados de: `Cnaes.zip`, `Motivos.zip`, `Municipios.zip`, `Paises.zip`, `Naturezas.zip`, `Qualificacoes.zip` e códigos dos municípios do IBGE | Em memória |
+| 2 | Armazena pares de chave e valor em disco para os dados de: `Empresas*` (já enriquecidas com dados de `Cnaes.zip`, `Motivos.zip`, `Municipios.zip`, `Paises.zip`, `Naturezas.zip`, `Qualificacoes.zip` e códigos dos municípios do IBGE), `Socios*` (já enriquecidos com pares de chave e valor de `Qualificacoes.zip`) e `Simples.zip` | [Badger](https://dgraph.io/docs/badger/) |
+| 3 | Lê os arquivos `Estabelecimentos*` e os enriquece com os dados das etapas anteriores | Em memória |
+| 4 | Convert o `struct` para JSON e armazena o resultado no banco de dados | PostgreSQL |
 
 ## Amostra dos arquivos para testes
 

--- a/transform/badger.go
+++ b/transform/badger.go
@@ -10,53 +10,11 @@ import (
 
 const badgerFilePrefix = "minha-receita-badger-"
 
-func removeLeadingZeros(n string) string {
-	var o string
-	isZero := true
-	for _, ch := range n {
-		if ch != '0' || !isZero {
-			o += string(ch)
-			isZero = false
-		}
-	}
-	if o == "" {
-		o = "0"
-	}
-	return o
-}
-
-func keyForMotives(n string) string  { return fmt.Sprintf("motives%s", removeLeadingZeros(n)) }
 func keyForPartners(n string) string { return fmt.Sprintf("partners%s", n) }
 func keyForBase(n string) string     { return fmt.Sprintf("base%s", n) }
 func keyForTaxes(n string) string    { return fmt.Sprintf("taxes%s", n) }
 
 // functions to read data from Badger
-
-func motivesOf(db *badger.DB, i int) (string, bool, error) {
-	var m string
-	found := false
-	n := fmt.Sprintf("%d", i)
-	err := db.View(func(txn *badger.Txn) error {
-		i, err := txn.Get([]byte(keyForMotives(n)))
-		if errors.Is(err, badger.ErrKeyNotFound) {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("could not get key %s: %w", keyForMotives(n), err)
-		}
-		v, err := i.ValueCopy(nil)
-		if err != nil {
-			return fmt.Errorf("could not read value for key %s: %w", keyForMotives(n), err)
-		}
-		m = string(v)
-		found = true
-		return nil
-	})
-	if err != nil {
-		return m, false, fmt.Errorf("error getting motive for %s: %w", n, err)
-	}
-	return m, found, nil
-}
 
 func partnersOf(db *badger.DB, n string) ([]partnerData, error) {
 	p := []partnerData{}

--- a/transform/badger.go
+++ b/transform/badger.go
@@ -10,7 +10,7 @@ import (
 
 const badgerFilePrefix = "minha-receita-badger-"
 
-func noLeadingZeros(n string) string {
+func removeLeadingZeros(n string) string {
 	var o string
 	isZero := true
 	for _, ch := range n {
@@ -25,37 +25,37 @@ func noLeadingZeros(n string) string {
 	return o
 }
 
-func keyForLookup(s sourceType, n string) string { return fmt.Sprintf("%s%s", s, noLeadingZeros(n)) }
-func keyForPartners(n string) string             { return fmt.Sprintf("partners%s", n) }
-func keyForBase(n string) string                 { return fmt.Sprintf("base%s", n) }
-func keyForTaxes(n string) string                { return fmt.Sprintf("taxes%s", n) }
+func keyForMotives(n string) string  { return fmt.Sprintf("motives%s", removeLeadingZeros(n)) }
+func keyForPartners(n string) string { return fmt.Sprintf("partners%s", n) }
+func keyForBase(n string) string     { return fmt.Sprintf("base%s", n) }
+func keyForTaxes(n string) string    { return fmt.Sprintf("taxes%s", n) }
 
 // functions to read data from Badger
 
-func lookupOf(db *badger.DB, s sourceType, i int) (string, bool, error) {
-	var v string
-	ok := false
+func motivesOf(db *badger.DB, i int) (string, bool, error) {
+	var m string
+	found := false
+	n := fmt.Sprintf("%d", i)
 	err := db.View(func(txn *badger.Txn) error {
-		k := keyForLookup(s, fmt.Sprintf("%d", i))
-		r, err := txn.Get([]byte(k))
+		i, err := txn.Get([]byte(keyForMotives(n)))
 		if errors.Is(err, badger.ErrKeyNotFound) {
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("could not get key %s: %w", k, err)
+			return fmt.Errorf("could not get key %s: %w", keyForMotives(n), err)
 		}
-		b, err := r.ValueCopy(nil)
+		v, err := i.ValueCopy(nil)
 		if err != nil {
-			return fmt.Errorf("could not read value for key %s: %w", k, err)
+			return fmt.Errorf("could not read value for key %s: %w", keyForMotives(n), err)
 		}
-		v = string(b)
-		ok = true
+		m = string(v)
+		found = true
 		return nil
 	})
 	if err != nil {
-		return v, false, fmt.Errorf("error getting %s for %d: %w", s, i, err)
+		return m, false, fmt.Errorf("error getting motive for %s: %w", n, err)
 	}
-	return v, ok, nil
+	return m, found, nil
 }
 
 func partnersOf(db *badger.DB, n string) ([]partnerData, error) {

--- a/transform/badger_test.go
+++ b/transform/badger_test.go
@@ -200,22 +200,3 @@ func TestSaveAndReadItems(t *testing.T) {
 		})
 	}
 }
-
-func TestRemoveLeadingZeros(t *testing.T) {
-	for _, tc := range []struct {
-		value    string
-		expected string
-	}{
-		{"42", "42"},
-		{"420", "420"},
-		{"042", "42"},
-		{"0042", "42"},
-		{"test", "test"},
-		{"0", "0"},
-	} {
-		got := removeLeadingZeros(tc.value)
-		if got != tc.expected {
-			t.Errorf("expected %s, got %s", tc.expected, got)
-		}
-	}
-}

--- a/transform/badger_test.go
+++ b/transform/badger_test.go
@@ -213,7 +213,7 @@ func TestRemoveLeadingZeros(t *testing.T) {
 		{"test", "test"},
 		{"0", "0"},
 	} {
-		got := noLeadingZeros(tc.value)
+		got := removeLeadingZeros(tc.value)
 		if got != tc.expected {
 			t.Errorf("expected %s, got %s", tc.expected, got)
 		}

--- a/transform/company.go
+++ b/transform/company.go
@@ -160,7 +160,7 @@ func newCompany(row []string, l *lookups, kv kvStorage, privacy bool) (company, 
 	}
 	c.DataSituacaoCadastral = dataSituacaoCadastral
 
-	if err := c.motivoSituacaoCadastral(row[7]); err != nil {
+	if err := c.motivoSituacaoCadastral(l, row[7]); err != nil {
 		return c, fmt.Errorf("error trying to parse MotivoSituacaoCadastral: %w", err)
 	}
 

--- a/transform/kv.go
+++ b/transform/kv.go
@@ -17,17 +17,14 @@ type item struct {
 	kind       sourceType
 }
 
-func lookupHandler(_ *lookups, r []string) ([]byte, error) { return []byte(r[1]), nil }
-
 func newKVItem(s sourceType, l *lookups, r []string) (i item, err error) {
 	var h func(l *lookups, r []string) ([]byte, error)
 	switch s {
 	case motives:
-		i.key = []byte(keyForLookup(motives, r[0]))
-		h = lookupHandler
-	case cities:
-		i.key = []byte(keyForLookup(cities, r[0]))
-		h = lookupHandler
+		i.key = []byte(keyForMotives(r[0]))
+		h = func(_ *lookups, r []string) ([]byte, error) {
+			return []byte(r[1]), nil
+		}
 	case partners:
 		i.key = []byte(keyForPartners(r[0]))
 		h = loadPartnerRow
@@ -49,13 +46,12 @@ func newKVItem(s sourceType, l *lookups, r []string) (i item, err error) {
 }
 
 type badgerStorage struct {
-	db       *badger.DB
-	path     string
-	gotError bool
+	db   *badger.DB
+	path string
 }
 
 func (kv *badgerStorage) load(dir string, l *lookups) error {
-	srcs, err := newSources(dir, []sourceType{motives, cities, base, partners, taxes})
+	srcs, err := newSources(dir, []sourceType{motives, base, partners, taxes})
 	if err != nil {
 		return fmt.Errorf("could not load sources: %w", err)
 	}
@@ -117,107 +113,55 @@ func (kv *badgerStorage) load(dir string, l *lookups) error {
 	}
 }
 
-type lookupResult struct {
-	value string
-	ok    bool
-}
-
-func (kv *badgerStorage) lookupHandler(ch chan<- lookupResult, errs chan<- error, s sourceType, k *int) {
-	var v string
-	var ok bool
-	if k == nil {
-		ch <- lookupResult{v, ok}
-		return
-	}
-	v, ok, err := lookupOf(kv.db, s, *k)
-	if err != nil {
-		if !kv.gotError {
-			errs <- err
-		}
-		kv.gotError = true
-		return
-	}
-	ch <- lookupResult{v, ok}
-}
-
-type lookupChannels struct {
-	motives chan lookupResult
-	cities  chan lookupResult
-}
-
-func (ls *lookupChannels) close() {
-	close(ls.motives)
-	close(ls.cities)
-}
-
 func (kv *badgerStorage) enrichCompany(c *company) error {
-	errs := make(chan error)
-	defer close(errs)
-
-	ch := lookupChannels{make(chan lookupResult), make(chan lookupResult)}
-	defer ch.close()
-
-	go kv.lookupHandler(ch.motives, errs, motives, c.MotivoSituacaoCadastral)
-	go kv.lookupHandler(ch.cities, errs, cities, c.CodigoMunicipio)
-
+	n := cnpj.Base(c.CNPJ)
+	ms := make(chan string)
 	ps := make(chan []partnerData)
 	bs := make(chan baseData)
 	ts := make(chan taxesData)
-	defer func() {
-		close(ts)
-		close(bs)
-		close(ps)
+	errs := make(chan error)
+	go func() {
+		if c.MotivoSituacaoCadastral == nil {
+			return
+		}
+		m, ok, err := motivesOf(kv.db, *c.MotivoSituacaoCadastral)
+		if err != nil {
+			errs <- err
+			return
+		}
+		if !ok {
+			return
+		}
+		ms <- m
 	}()
-	n := cnpj.Base(c.CNPJ)
 	go func() {
 		p, err := partnersOf(kv.db, n)
 		if err != nil {
-			if !kv.gotError {
-				errs <- err
-			}
-			kv.gotError = true
+			errs <- err
 			return
 		}
-		if !kv.gotError {
-			ps <- p
-		}
+		ps <- p
 	}()
 	go func() {
 		v, err := baseOf(kv.db, n)
 		if err != nil {
-			if !kv.gotError {
-				errs <- err
-			}
-			kv.gotError = true
+			errs <- err
 			return
 		}
-		if !kv.gotError {
-			bs <- v
-		}
+		bs <- v
 	}()
 	go func() {
 		t, err := taxesOf(kv.db, n)
 		if err != nil {
-			if !kv.gotError {
-				errs <- err
-			}
-			kv.gotError = true
+			errs <- err
 			return
 		}
-		if !kv.gotError {
-			ts <- t
-		}
+		ts <- t
 	}()
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 3; i++ {
 		select {
-		case r := <-ch.motives:
-			if r.ok {
-				c.DescricaoMotivoSituacaoCadastral = &r.value
-			}
-		case r := <-ch.cities:
-			if r.ok {
-				c.Municipio = &r.value
-			}
+		case m := <-ms:
+			c.DescricaoMotivoSituacaoCadastral = &m
 		case p := <-ps:
 			c.QuadroSocietario = p
 		case v := <-bs:

--- a/transform/lookups.go
+++ b/transform/lookups.go
@@ -22,6 +22,7 @@ func newLookup(p string) (lookup, error) {
 }
 
 type lookups struct {
+	cities         lookup
 	countries      lookup
 	cnaes          lookup
 	qualifications lookup
@@ -31,7 +32,7 @@ type lookups struct {
 
 func newLookups(d string) (lookups, error) {
 	var ls []lookup
-	srcs := []sourceType{countries, cnaes, qualifications, natures}
+	srcs := []sourceType{cities, countries, cnaes, qualifications, natures}
 	for _, src := range srcs {
 		paths, err := pathsForSource(src, d)
 		if err != nil {
@@ -52,10 +53,10 @@ func newLookups(d string) (lookups, error) {
 	if err != nil {
 		return lookups{}, fmt.Errorf("error creating ibge lookup: %w", err)
 	}
-	return lookups{ls[0], ls[1], ls[2], ls[3], c}, nil
+	return lookups{ls[0], ls[1], ls[2], ls[3], ls[4], c}, nil
 }
 
-func (c *company) motivoSituacaoCadastral(v string) error {
+func (c *company) motivoSituacaoCadastral(l *lookups, v string) error {
 	i, err := toInt(v)
 	if err != nil {
 		return fmt.Errorf("error trying to parse MotivoSituacaoCadastral %s: %w", v, err)
@@ -95,6 +96,11 @@ func (c *company) municipio(l *lookups, v string) error {
 		return nil
 	}
 	c.CodigoMunicipio = i
+	s, ok := l.cities[*i]
+	if !ok {
+		return nil
+	}
+	c.Municipio = &s
 	ibge, ok := l.ibge[*i]
 	if !ok {
 		log.Output(1, fmt.Sprintf("Could not find IBGE city code for %s-%s (%d)", *c.Municipio, c.UF, *i))

--- a/transform/lookups.go
+++ b/transform/lookups.go
@@ -22,6 +22,7 @@ func newLookup(p string) (lookup, error) {
 }
 
 type lookups struct {
+	motives        lookup
 	cities         lookup
 	countries      lookup
 	cnaes          lookup
@@ -32,7 +33,7 @@ type lookups struct {
 
 func newLookups(d string) (lookups, error) {
 	var ls []lookup
-	srcs := []sourceType{cities, countries, cnaes, qualifications, natures}
+	srcs := []sourceType{motives, cities, countries, cnaes, qualifications, natures}
 	for _, src := range srcs {
 		paths, err := pathsForSource(src, d)
 		if err != nil {
@@ -53,7 +54,7 @@ func newLookups(d string) (lookups, error) {
 	if err != nil {
 		return lookups{}, fmt.Errorf("error creating ibge lookup: %w", err)
 	}
-	return lookups{ls[0], ls[1], ls[2], ls[3], ls[4], c}, nil
+	return lookups{ls[0], ls[1], ls[2], ls[3], ls[4], ls[5], c}, nil
 }
 
 func (c *company) motivoSituacaoCadastral(l *lookups, v string) error {
@@ -64,7 +65,11 @@ func (c *company) motivoSituacaoCadastral(l *lookups, v string) error {
 	if i == nil {
 		return nil
 	}
+	s := l.motives[*i]
 	c.MotivoSituacaoCadastral = i
+	if s != "" {
+		c.DescricaoMotivoSituacaoCadastral = &s
+	}
 	return nil
 }
 


### PR DESCRIPTION
Ao contrário do previsto, essa ideia vai complexificar mais ainda o código, pois uma consulta de look-up no Badger (por exemplo, por naturza na base, ou por país em cada pessoa do quadro societário) vai depender de outra.

Closes #197