### PR TITLE
Fecha adequadamente o banco de dados de chave-valor entre os passos 1 e 2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,5 +49,3 @@ require (
 	google.golang.org/grpc v1.65.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 )
-
-// +heroku goVersion go1.22

--- a/transform/company_test.go
+++ b/transform/company_test.go
@@ -108,7 +108,7 @@ func TestNewCompany(t *testing.T) {
 	}
 
 	t.Run("with privacy", func(t *testing.T) {
-		tmp, err := os.MkdirTemp("", fmt.Sprintf("%s-%s", badgerFilePrefix, time.Now().Format("20060102150405")))
+		tmp, err := os.MkdirTemp("", fmt.Sprintf("minha-receita-%s-*", time.Now().Format("20060102150405")))
 		if err != nil {
 			t.Fatal("error creating temporary key-value storage: %w", err)
 		}
@@ -117,7 +117,7 @@ func TestNewCompany(t *testing.T) {
 		if err != nil {
 			t.Errorf("expected no error creating badger, got %s", err)
 		}
-		defer kv.close(false)
+		defer kv.close()
 		lookups, err := newLookups(testdata)
 		if err != nil {
 			t.Errorf("expected no errors creating look up tables, got %v", err)
@@ -264,7 +264,7 @@ func TestNewCompany(t *testing.T) {
 		}
 	})
 	t.Run("without privacy", func(t *testing.T) {
-		tmp, err := os.MkdirTemp("", fmt.Sprintf("%s-%s", badgerFilePrefix, time.Now().Format("20060102150405")))
+		tmp, err := os.MkdirTemp("", fmt.Sprintf("minha-receita-%s-*", time.Now().Format("20060102150405")))
 		if err != nil {
 			t.Fatal("error creating temporary key-value storage: %w", err)
 		}
@@ -273,7 +273,7 @@ func TestNewCompany(t *testing.T) {
 		if err != nil {
 			t.Errorf("expected no error creating badger, got %s", err)
 		}
-		defer kv.close(false)
+		defer kv.close()
 		lookups, err := newLookups(testdata)
 		if err != nil {
 			t.Errorf("expected no errors creating look up tables, got %v", err)

--- a/transform/company_test.go
+++ b/transform/company_test.go
@@ -117,7 +117,7 @@ func TestNewCompany(t *testing.T) {
 		if err != nil {
 			t.Errorf("expected no error creating badger, got %s", err)
 		}
-		defer kv.close()
+		defer kv.close(false)
 		lookups, err := newLookups(testdata)
 		if err != nil {
 			t.Errorf("expected no errors creating look up tables, got %v", err)
@@ -273,7 +273,7 @@ func TestNewCompany(t *testing.T) {
 		if err != nil {
 			t.Errorf("expected no error creating badger, got %s", err)
 		}
-		defer kv.close()
+		defer kv.close(false)
 		lookups, err := newLookups(testdata)
 		if err != nil {
 			t.Errorf("expected no errors creating look up tables, got %v", err)

--- a/transform/kv.go
+++ b/transform/kv.go
@@ -162,9 +162,9 @@ func (kv *badgerStorage) enrichCompany(c *company) error {
 	return nil
 }
 
-func (b *badgerStorage) close() error {
+func (b *badgerStorage) close(k bool) error {
 	b.db.Close()
-	if b.path != "" {
+	if !k && b.path != ""  {
 		if err := os.RemoveAll(b.path); err != nil {
 			return fmt.Errorf("error cleaning up badger storage directory: %w", err)
 		}

--- a/transform/kv.go
+++ b/transform/kv.go
@@ -164,7 +164,7 @@ func (kv *badgerStorage) enrichCompany(c *company) error {
 
 func (b *badgerStorage) close(k bool) error {
 	b.db.Close()
-	if !k && b.path != ""  {
+	if !k {
 		if err := os.RemoveAll(b.path); err != nil {
 			return fmt.Errorf("error cleaning up badger storage directory: %w", err)
 		}

--- a/transform/kv_test.go
+++ b/transform/kv_test.go
@@ -19,7 +19,7 @@ func TestBadgerStorageClose(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error creating badger storage, got %s", err)
 	}
-	if err := kv.close(); err != nil {
+	if err := kv.close(false); err != nil {
 		t.Errorf("expected no error closing badger storage, got %s", err)
 	}
 	if _, err := os.Stat(kv.path); err == nil || !os.IsNotExist(err) {
@@ -74,7 +74,7 @@ func TestLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create badger storage: %s", err)
 	}
-	defer kv.close()
+	defer kv.close(false)
 	if err := kv.load(testdata, &l); err != nil {
 		t.Errorf("expected no error loading data, got %s", err)
 	}
@@ -103,7 +103,7 @@ func TestEnrichCompany(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create badger storage: %s", err)
 	}
-	defer kv.close()
+	defer kv.close(false)
 	if err := kv.load(testdata, &l); err != nil {
 		t.Errorf("expected no error loading data, got %s", err)
 	}

--- a/transform/kv_test.go
+++ b/transform/kv_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestBadgerStorageClose(t *testing.T) {
-	tmp, err := os.MkdirTemp("", fmt.Sprintf("%s-%s", badgerFilePrefix, time.Now().Format("20060102150405")))
+	tmp, err := os.MkdirTemp("", fmt.Sprintf("minha-receita-%s-*", time.Now().Format("20060102150405")))
 	if err != nil {
 		t.Fatal("error creating temporary key-value storage: %w", err)
 	}
@@ -19,11 +19,8 @@ func TestBadgerStorageClose(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error creating badger storage, got %s", err)
 	}
-	if err := kv.close(false); err != nil {
+	if err := kv.close(); err != nil {
 		t.Errorf("expected no error closing badger storage, got %s", err)
-	}
-	if _, err := os.Stat(kv.path); err == nil || !os.IsNotExist(err) {
-		t.Errorf("expected %s to be gone, but got %s when opening it", kv.path, err)
 	}
 }
 
@@ -65,7 +62,7 @@ func TestLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create lookups: %s", err)
 	}
-	tmp, err := os.MkdirTemp("", fmt.Sprintf("%s-%s", badgerFilePrefix, time.Now().Format("20060102150405")))
+	tmp, err := os.MkdirTemp("", fmt.Sprintf("minha-receita-%s-*", time.Now().Format("20060102150405")))
 	if err != nil {
 		t.Fatal("error creating temporary key-value storage: %w", err)
 	}
@@ -74,7 +71,7 @@ func TestLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create badger storage: %s", err)
 	}
-	defer kv.close(false)
+	defer kv.close()
 	if err := kv.load(testdata, &l); err != nil {
 		t.Errorf("expected no error loading data, got %s", err)
 	}
@@ -94,7 +91,7 @@ func TestEnrichCompany(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create lookups: %s", err)
 	}
-	tmp, err := os.MkdirTemp("", fmt.Sprintf("%s-%s", badgerFilePrefix, time.Now().Format("20060102150405")))
+	tmp, err := os.MkdirTemp("", fmt.Sprintf("minha-receita-%s-*", time.Now().Format("20060102150405")))
 	if err != nil {
 		t.Fatal("error creating temporary key-value storage: %w", err)
 	}
@@ -103,7 +100,7 @@ func TestEnrichCompany(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create badger storage: %s", err)
 	}
-	defer kv.close(false)
+	defer kv.close()
 	if err := kv.load(testdata, &l); err != nil {
 		t.Errorf("expected no error loading data, got %s", err)
 	}

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -33,7 +33,7 @@ type database interface {
 type kvStorage interface {
 	load(string, *lookups) error
 	enrichCompany(*company) error
-	close() error
+	close(bool) error
 }
 
 type mode int

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -84,6 +84,7 @@ func runStepOne(dir string, l lookups, isolated bool) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not create badger storage: %w", err)
 	}
+	defer kv.close(isolated)
 	if err := kv.load(dir, &l); err != nil {
 		return "", fmt.Errorf("error loading data to badger: %w", err)
 	}
@@ -98,9 +99,7 @@ func runStepTwo(dir string, tmp string, db database, l lookups, maxParallelDBQue
 	if err != nil {
 		return fmt.Errorf("could not create badger storage: %w", err)
 	}
-	if !isolated {
-		defer kv.close()
-	}
+	defer kv.close(isolated)
 	j, err := createJSONRecordsTask(dir, db, &l, kv, batchSize, privacy)
 	if err != nil {
 		return fmt.Errorf("error creating new task for venues in %s: %w", dir, err)

--- a/transform/venues_test.go
+++ b/transform/venues_test.go
@@ -18,7 +18,7 @@ func TestTaskRun(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error creating badger, got %s", err)
 	}
-	defer kv.close()
+	defer kv.close(false)
 	lookups, err := newLookups(testdata)
 	if err != nil {
 		t.Errorf("expected no errors creating look up tables, got %v", err)

--- a/transform/venues_test.go
+++ b/transform/venues_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestTaskRun(t *testing.T) {
 	db := newTestDB(t)
-	tmp, err := os.MkdirTemp("", fmt.Sprintf("%s-%s", badgerFilePrefix, time.Now().Format("20060102150405")))
+	tmp, err := os.MkdirTemp("", fmt.Sprintf("minha-receita-%s-*", time.Now().Format("20060102150405")))
 	if err != nil {
 		t.Fatal("error creating temporary key-value storage: %w", err)
 	}
@@ -18,7 +18,7 @@ func TestTaskRun(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error creating badger, got %s", err)
 	}
-	defer kv.close(false)
+	defer kv.close()
 	lookups, err := newLookups(testdata)
 	if err != nil {
 		t.Errorf("expected no errors creating look up tables, got %v", err)


### PR DESCRIPTION
Closes #253 — obrigada, @silvioes pelo _bur report_ super detalhado.

Esse PR resolve o bug mencionado acima refatorando parte da lógica do Badger para:
* simplificar o código
* mover o gerenciamento do diretório temporário para o comando `transform` (não para nosso envelopamento do Badger)
