### PR TITLE
Possibilidade de criar os índices extras via CLI

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -67,6 +67,19 @@ var dropCmd = &cobra.Command{
 	},
 }
 
+var extraIndexesCmd = &cobra.Command{
+	Use:   "extra-indexes",
+	Short: "Creates indexes in database", //Acho que essa explicacao pode melhorar
+	RunE: func(_ *cobra.Command, args []string) error {
+		db, err := loadDatabase()
+		if err != nil {
+			return fmt.Errorf("could not find database: %w", err)
+		}
+		defer db.Close()
+		return db.ExtraIndexes(args)
+	},
+}
+
 func addDataDir(c *cobra.Command) *cobra.Command {
 	c.Flags().StringVarP(&dir, "directory", "d", defaultDataDir, "directory of the downloaded files")
 	return c
@@ -80,7 +93,7 @@ func addDatabase(c *cobra.Command) *cobra.Command {
 
 // CLI returns the root command from Cobra CLI tool.
 func CLI() *cobra.Command {
-	for _, c := range []*cobra.Command{createCmd, dropCmd} {
+	for _, c := range []*cobra.Command{createCmd, dropCmd, extraIndexesCmd} {
 		addDatabase(c)
 	}
 	for _, c := range []*cobra.Command{
@@ -92,6 +105,7 @@ func CLI() *cobra.Command {
 		checkCLI(),
 		createCmd,
 		dropCmd,
+		extraIndexesCmd,
 		transformCLI(),
 		sampleCLI(),
 		mirrorCLI(),

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -69,7 +69,7 @@ var dropCmd = &cobra.Command{
 
 var extraIndexesCmd = &cobra.Command{
 	Use:   "extra-indexes",
-	Short: "Creates indexes in database", //Acho que essa explicacao pode melhorar
+	Short: "Creates extra indexes in the company field",
 	RunE: func(_ *cobra.Command, args []string) error {
 		db, err := loadDatabase()
 		if err != nil {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -68,8 +68,9 @@ var dropCmd = &cobra.Command{
 }
 
 var extraIndexesCmd = &cobra.Command{
-	Use:   "extra-indexes",
-	Short: "Creates extra indexes in the company field",
+	Use:   "extra-indexes index-1 [index-2 …]",
+	Short: "Creates extra indexes in the JSON fields",
+	Args:  cobra.MinimumNArgs(1),
 	RunE: func(_ *cobra.Command, args []string) error {
 		db, err := loadDatabase()
 		if err != nil {

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -22,6 +22,7 @@ type database interface {
 	CreateCompanies([][]string) error
 	PostLoad() error
 	MetaSave(string, string) error
+	ExtraIndexes(idxs []string) error
 	// api
 	GetCompany(string) (string, error)
 	MetaRead(string) (string, error)

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -225,7 +225,7 @@ func (m *MongoDB) GetCompany(cnpj string) (string, error) {
 }
 
 func (m *MongoDB) ExtraIndexes(idxs []string) error {
-	log.Output(1, "Creating the indexes...")
+   log.Output(1, "Creating the indexes…")
 	c := m.db.Collection(companyTableName)
 	var i []mongo.IndexModel
 	for _, field := range idxs {

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -228,9 +228,16 @@ func (m *MongoDB) ExtraIndexes(idxs []string) error {
 	log.Output(1, "Creating the indexes…")
 	c := m.db.Collection(companyTableName)
 	var i []mongo.IndexModel
-	for _, field := range idxs {
+	for _, v := range idxs {
+		if strings.Contains(v, "qsa_") {
+			v = strings.ReplaceAll(strings.Replace(v, "qsa_", "", 1), "_", "")
+			v = fmt.Sprintf("%s_%s", "qsa", v)
+		}
+		if strings.Contains(v, "secundario") && strings.Contains(v, "cnae") {
+			v = fmt.Sprintf("cnaesecundarios_%s", strings.Split(v, "secundarios_")[1])
+		}
 		i = append(i, mongo.IndexModel{
-			Keys: bson.D{{Key: field, Value: 1}},
+			Keys: bson.D{{Key: v, Value: 1}},
 		})
 	}
 	r, err := c.Indexes().CreateMany(m.ctx, i)

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -232,14 +232,17 @@ func (m *MongoDB) ExtraIndexes(idxs []string) error {
 		e := strings.Split(v, ".")
 		if len(e) > 1 {
 			v = strings.ReplaceAll(e[1], "_", "")
-			if strings.Contains(e[0], "qsa") {    // Se for qsa.index1 ele so converte para qsa_index1
+			if e[0] == "qsa" {
 				v = fmt.Sprintf("%s.%s", "qsa", v)
 			}
-			if strings.Contains(e[0], "secundario") && strings.Contains(e[0], "cnae") { //Aqui no json esta cnaes_secundarios se o usuario digitar qualquer coisa proxima ele converte para o padrao
+			if e[0] == "cnaes_secundarios" {
 				v = fmt.Sprintf("cnaesecundarios.%s", e[1])
+			} else {
+				log.Output(1, fmt.Sprintf("the index %s does not exist in json, so it cannot be created.", e[0]))
+				return nil
 			}
 		}
-		v = fmt.Sprintf("json.%s", v) // concatena o json. que e o nome da raiz
+		v = fmt.Sprintf("json.%s", v)
 		i = append(i, mongo.IndexModel{
 			Keys: bson.D{{Key: v, Value: 1}},
 		})
@@ -251,4 +254,28 @@ func (m *MongoDB) ExtraIndexes(idxs []string) error {
 	log.Output(1, fmt.Sprintf("%d indexes successfully created in the collection %s", len(r), companyTableName))
 	return nil
 
+}
+
+func (m *MongoDB) checkIndexes(indexes []string) (map[string]bool, error) {
+	c := m.db.Collection(companyTableName)
+	cur, err := c.Indexes().List(m.ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cur.Close(m.ctx)
+	idxs := make(map[string]bool)
+	for cur.Next(m.ctx) {
+		var idx bson.M
+		if err := cur.Decode(&idx); err != nil {
+			return nil, err
+		}
+		if n, ok := idx["name"].(string); ok {
+			idxs[n] = true
+		}
+	}
+	r := make(map[string]bool)
+	for _, index := range indexes {
+		r[index] = idxs[index]
+	}
+	return r, nil
 }

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -233,7 +233,7 @@ func (m *MongoDB) ExtraIndexes(idxs []string) error {
 		if len(e) > 1 {
 			v = strings.ReplaceAll(e[1], "_", "")
 			if e[0] == "qsa" {
-				v = fmt.Sprintf("%s.%s", "qsa", v)
+				v = fmt.Sprintf("%s.%s", e[0], v)
 			}
 			if e[0] == "cnaes_secundarios" {
 				v = fmt.Sprintf("cnaesecundarios.%s", e[1])

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -231,7 +231,7 @@ func (m *MongoDB) ExtraIndexes(idxs []string) error {
 	for _, v := range idxs {
 		e := strings.Split(v, ".")
 		if len(e) > 1 {
-			v = strings.ReplaceAll(e[1], "_", "") // Se todo indice apos o . tiver um _ ele remove e deixa no padrao que esta no mongodb.
+			v = strings.ReplaceAll(e[1], "_", "")
 			if strings.Contains(e[0], "qsa") {    // Se for qsa.index1 ele so converte para qsa_index1
 				v = fmt.Sprintf("%s.%s", "qsa", v)
 			}

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -233,11 +233,11 @@ func (m *MongoDB) ExtraIndexes(idxs []string) error {
 			Keys: bson.D{{Key: field, Value: 1}},
 		})
 	}
-	_, err := c.Indexes().CreateMany(m.ctx, i)
+	r, err := c.Indexes().CreateMany(m.ctx, i)
 	if err != nil {
 		return fmt.Errorf("error creating indexes: %w", err)
 	}
-	log.Output(1, fmt.Sprintf("Indexes successfully created in the collection %s", companyTableName))
+	log.Output(1, fmt.Sprintf("%d indexes successfully created in the collection %s", len(r), companyTableName))
 	return nil
 
 }

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -225,7 +225,7 @@ func (m *MongoDB) GetCompany(cnpj string) (string, error) {
 }
 
 func (m *MongoDB) ExtraIndexes(idxs []string) error {
-   log.Output(1, "Creating the indexes…")
+	log.Output(1, "Creating the indexes…")
 	c := m.db.Collection(companyTableName)
 	var i []mongo.IndexModel
 	for _, field := range idxs {

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -223,3 +223,21 @@ func (m *MongoDB) GetCompany(cnpj string) (string, error) {
 	}
 	return string(b), nil
 }
+
+func (m *MongoDB) ExtraIndexes(idxs []string) error {
+	log.Output(1, "Creating the indexes...")
+	c := m.db.Collection(companyTableName)
+	var i []mongo.IndexModel
+	for _, field := range idxs {
+		i = append(i, mongo.IndexModel{
+			Keys: bson.D{{Key: field, Value: 1}},
+		})
+	}
+	_, err := c.Indexes().CreateMany(m.ctx, i)
+	if err != nil {
+		return fmt.Errorf("error creating indexes: %w", err)
+	}
+	log.Output(1, fmt.Sprintf("Indexes successfully created in the collection %s", companyTableName))
+	return nil
+
+}

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -229,13 +229,17 @@ func (m *MongoDB) ExtraIndexes(idxs []string) error {
 	c := m.db.Collection(companyTableName)
 	var i []mongo.IndexModel
 	for _, v := range idxs {
-		if strings.Contains(v, "qsa_") {
-			v = strings.ReplaceAll(strings.Replace(v, "qsa_", "", 1), "_", "")
-			v = fmt.Sprintf("%s_%s", "qsa", v)
+		e := strings.Split(v, ".")
+		if len(e) > 1 {
+			v = strings.ReplaceAll(e[1], "_", "") // Se todo indice apos o . tiver um _ ele remove e deixa no padrao que esta no mongodb.
+			if strings.Contains(e[0], "qsa") {    // Se for qsa.index1 ele so converte para qsa_index1
+				v = fmt.Sprintf("%s.%s", "qsa", v)
+			}
+			if strings.Contains(e[0], "secundario") && strings.Contains(e[0], "cnae") { //Aqui no json esta cnaes_secundarios se o usuario digitar qualquer coisa proxima ele converte para o padrao
+				v = fmt.Sprintf("cnaesecundarios.%s", e[1])
+			}
 		}
-		if strings.Contains(v, "secundario") && strings.Contains(v, "cnae") {
-			v = fmt.Sprintf("cnaesecundarios_%s", strings.Split(v, "secundarios_")[1])
-		}
+		v = fmt.Sprintf("json.%s", v) // concatena o json. que e o nome da raiz
 		i = append(i, mongo.IndexModel{
 			Keys: bson.D{{Key: v, Value: 1}},
 		})

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -234,8 +234,7 @@ func (m *MongoDB) ExtraIndexes(idxs []string) error {
 			v = strings.ReplaceAll(e[1], "_", "")
 			if e[0] == "qsa" {
 				v = fmt.Sprintf("%s.%s", e[0], v)
-			}
-			if e[0] == "cnaes_secundarios" {
+			} else if e[0] == "cnaes_secundarios" {
 				v = fmt.Sprintf("cnaesecundarios.%s", e[1])
 			} else {
 				log.Output(1, fmt.Sprintf("the index %s does not exist in json, so it cannot be created.", e[0]))
@@ -254,28 +253,4 @@ func (m *MongoDB) ExtraIndexes(idxs []string) error {
 	log.Output(1, fmt.Sprintf("%d indexes successfully created in the collection %s", len(r), companyTableName))
 	return nil
 
-}
-
-func (m *MongoDB) checkIndexes(indexes []string) (map[string]bool, error) {
-	c := m.db.Collection(companyTableName)
-	cur, err := c.Indexes().List(m.ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer cur.Close(m.ctx)
-	idxs := make(map[string]bool)
-	for cur.Next(m.ctx) {
-		var idx bson.M
-		if err := cur.Decode(&idx); err != nil {
-			return nil, err
-		}
-		if n, ok := idx["name"].(string); ok {
-			idxs[n] = true
-		}
-	}
-	r := make(map[string]bool)
-	for _, index := range indexes {
-		r[index] = idxs[index]
-	}
-	return r, nil
 }

--- a/db/mongodb_test.go
+++ b/db/mongodb_test.go
@@ -3,8 +3,6 @@ package db
 import (
 	"os"
 	"testing"
-
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 func TestMongoDB(t *testing.T) {
@@ -82,28 +80,4 @@ func TestMongoDB(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected array as the answer, got %s", err)
 	}
-}
-
-func (m *MongoDB) checkIndexes(indexes []string) (map[string]bool, error) {
-	c := m.db.Collection(companyTableName)
-	cur, err := c.Indexes().List(m.ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer cur.Close(m.ctx)
-	idxs := make(map[string]bool)
-	for cur.Next(m.ctx) {
-		var idx bson.M
-		if err := cur.Decode(&idx); err != nil {
-			return nil, err
-		}
-		if n, ok := idx["name"].(string); ok {
-			existingIndexes[name] = true
-		}
-	}
-	r := make(map[string]bool)
-	for _, index := range indexes {
-		result[index] = existingIndexes[index]
-	}
-	return result, nil
 }

--- a/db/mongodb_test.go
+++ b/db/mongodb_test.go
@@ -97,7 +97,7 @@ func (m *MongoDB) checkIndexes(indexes []string) (map[string]bool, error) {
 		if err := cur.Decode(&idx); err != nil {
 			return nil, err
 		}
-		if name, ok := idx["name"].(string); ok {
+		if n, ok := idx["name"].(string); ok {
 			existingIndexes[name] = true
 		}
 	}

--- a/db/mongodb_test.go
+++ b/db/mongodb_test.go
@@ -101,7 +101,7 @@ func (m *MongoDB) checkIndexes(indexes []string) (map[string]bool, error) {
 			existingIndexes[name] = true
 		}
 	}
-	result := make(map[string]bool)
+	r := make(map[string]bool)
 	for _, index := range indexes {
 		result[index] = existingIndexes[index]
 	}

--- a/db/mongodb_test.go
+++ b/db/mongodb_test.go
@@ -91,7 +91,7 @@ func (m *MongoDB) checkIndexes(indexes []string) (map[string]bool, error) {
 		return nil, err
 	}
 	defer cur.Close(m.ctx)
-	existingIndexes := make(map[string]bool)
+	idxs := make(map[string]bool)
 	for cur.Next(m.ctx) {
 		var idx bson.M
 		if err := cur.Decode(&idx); err != nil {

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -212,3 +212,18 @@ func NewPostgreSQL(uri, schema string) (PostgreSQL, error) {
 	}
 	return p, nil
 }
+
+func (p *PostgreSQL) ExtraIndexes(idxs []string) error {
+	cols := strings.Join(idxs, ", ")
+	fmt.Println(companyTableName)
+	fmt.Println(p.CompanyTableFullName())
+	query := fmt.Sprintf(
+		"CREATE INDEX IF NOT EXISTS %s_pk ON %s (%s);",
+		companyTableName, p.JSONFieldName, cols,
+	)
+	if _, err := p.pool.Exec(context.Background(), query); err != nil {
+		return fmt.Errorf("error to create indexes %s: %w", cols, err)
+	}
+	log.Output(1, "Indexes created")
+	return nil
+}

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -29,6 +29,12 @@ const (
 //go:embed postgres
 var sql embed.FS
 
+type ExtraIndexes struct {
+	Type  string
+	Name  string
+	Value string
+}
+
 // PostgreSQL database interface.
 type PostgreSQL struct {
 	pool                  *pgxpool.Pool
@@ -43,7 +49,7 @@ type PostgreSQL struct {
 	KeyFieldName          string
 	ValueFieldName        string
 	PartnersJSONFieldName string
-	OptExtraIndexes       map[string]string
+	ExtraIndexesFields    ExtraIndexes
 }
 
 func (p *PostgreSQL) loadTemplates() error {
@@ -235,11 +241,9 @@ func (p *PostgreSQL) ExtraIndexes(idxs []string) error {
 			valueIdx = v
 		}
 
-		p.OptExtraIndexes = map[string]string{
-			"TypeIdx":  typeIdx,
-			"NameIdx":  nameIdx,
-			"ValueIdx": valueIdx,
-		}
+		p.ExtraIndexesFields.Type = typeIdx
+		p.ExtraIndexesFields.Name = nameIdx
+		p.ExtraIndexesFields.Value = valueIdx
 
 		_, err := p.pool.Exec(context.Background(), p.sql["extra_indexes"])
 		if err != nil {

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -236,10 +236,13 @@ func (p *PostgreSQL) ExtraIndexes(idxs []string) error {
 		if _, err := p.pool.Exec(context.Background(), q); err != nil {
 			return fmt.Errorf("error to create indexe %s: %w", v, err)
 		}
+		// name = fmt.Sprintf("idx_%s%s", name, v)
+		// _, err := p.pool.Query(context.Background(), p.sql["extra_indexes"], name, p.CompanyTableName, v)
+		// if err != nil {
+		// 	return fmt.Errorf("error to create indexe %s: %w", v, err)
+		// }
 		c += 1
 	}
-
 	log.Output(1, fmt.Sprintf("%d Indexes successfully created in the table %s", c, p.CompanyTableName))
-
 	return nil
 }

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -215,8 +215,7 @@ func NewPostgreSQL(uri, schema string) (PostgreSQL, error) {
 }
 
 func (p *PostgreSQL) ExtraIndexes(idxs []string) error {
-	c := 0
-	for _, idx := range idxs {
+	for c, idx := range idxs {
 		v := idx
 		name := "json_"
 

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -221,10 +221,10 @@ func NewPostgreSQL(uri, schema string) (PostgreSQL, error) {
 }
 
 func (p *PostgreSQL) ExtraIndexes(idxs []string) error {
-	for c, idx := range idxs {
+	c := 0
+	for _, idx := range idxs {
 		v := idx
 		name := "json_"
-
 		typeIdx := "root"
 		nameIdx := fmt.Sprintf("%s%s", name, v)
 		valueIdx := idx
@@ -240,11 +240,10 @@ func (p *PostgreSQL) ExtraIndexes(idxs []string) error {
 			}
 			valueIdx = v
 		}
-
 		p.ExtraIndexesFields.Type = typeIdx
 		p.ExtraIndexesFields.Name = nameIdx
 		p.ExtraIndexesFields.Value = valueIdx
-
+		p.loadTemplates()
 		_, err := p.pool.Exec(context.Background(), p.sql["extra_indexes"])
 		if err != nil {
 			return fmt.Errorf("error to create indexe %s: %w", v, err)

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -220,7 +220,7 @@ func (p *PostgreSQL) ExtraIndexes(idxs []string) error {
 		qsa := []string{"pais", "nome_socio", "codigo_pais", "faixa_etaria", "cnpj_cpf_do_socio", "qualificacao_socio", "codigo_faixa_etaria", "data_entrada_sociedade", "identificador_de_socio", "cpf_representante_legal", "nome_representante_legal", "codigo_qualificacao_socio", "qualificacao_representante_legal", "codigo_qualificacao_representante_legal"}
 		for _, v_qsa := range qsa {
 			if v == v_qsa {
-				t = "(jsonb_extract_path(json, 'qsa', '" + v_qsa + "') jsonb_ops)"
+				t = fmt.Sprintf("(jsonb_extract_path(json, 'qsa', '%s') jsonb_ops)", v_qsa)
 				iname += "qsa_"
 				break
 			}
@@ -228,7 +228,7 @@ func (p *PostgreSQL) ExtraIndexes(idxs []string) error {
 		cnae := []string{"codigo", "descricao"}
 		for _, v_cnae := range cnae {
 			if v == v_cnae {
-				t = "(jsonb_extract_path(json, 'cnae', '" + v_cnae + "') jsonb_ops)"
+				t = fmt.Sprintf("(jsonb_extract_path(json, 'cnae', '%s') jsonb_ops)", v_cnae)
 				iname += "cnae_"
 				break
 			}
@@ -240,7 +240,7 @@ func (p *PostgreSQL) ExtraIndexes(idxs []string) error {
 		if _, err := p.pool.Exec(context.Background(), q); err != nil {
 			return fmt.Errorf("error to create indexe %s: %w", v, err)
 		}
-		log.Output(1, "Indexe "+v+" created")
+		log.Output(1, fmt.Sprintf("Indexes successfully created in the collection %s", p.CompanyTableName))
 	}
 
 	return nil

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -222,27 +222,16 @@ func (p *PostgreSQL) ExtraIndexes(idxs []string) error {
 			v = strings.Split(v, ".")[1]
 			if strings.Contains(v, "qsa") {
 				t = fmt.Sprintf("jsonb_extract_path(json, 'qsa', '%s') jsonb_ops", v)
-				name += "qsa_"
+				name = fmt.Sprintf("%sqsa_", name)
 			}
 			if strings.Contains(v, "cnae") {
 				t = fmt.Sprintf("jsonb_extract_path(json, 'cnaes_secundarios', '%s') jsonb_ops", v)
-				name += "cnaes_secundarios_"
+				name = fmt.Sprintf("%scnaes_secundarios_", name)
 			}
 		}
-		// q := fmt.Sprintf(
-		// 	"CREATE INDEX IF NOT EXISTS idx_%s%s ON %s USING GIN %s;",
-		// 	name, v, p.CompanyTableName, t,
-		// )
-		// if _, err := p.pool.Exec(context.Background(), q); err != nil {
-		// 	return fmt.Errorf("error to create indexe %s: %w", v, err)
-		// }
+
 		p.IDFieldName = fmt.Sprintf("%s%s", name, v)
 		p.JSONFieldName = t
-		fmt.Printf("%s", p.IDFieldName)
-		fmt.Println()
-		fmt.Printf("%s", p.JSONFieldName)
-		fmt.Sprintf("%s", p.sql["extra_indexes"])
-		fmt.Println()
 		_, err := p.pool.Query(context.Background(), p.sql["extra_indexes"])
 		if err != nil {
 			return fmt.Errorf("error to create indexe %s: %w", v, err)

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -240,7 +240,7 @@ func (p *PostgreSQL) ExtraIndexes(idxs []string) error {
 		if _, err := p.pool.Exec(context.Background(), q); err != nil {
 			return fmt.Errorf("error to create indexe %s: %w", v, err)
 		}
-		log.Output(1, fmt.Sprintf("Indexes successfully created in the collection %s", p.CompanyTableName))
+		log.Output(1, fmt.Sprintf("Indexes successfully created for table %s", p.CompanyTableName))
 	}
 
 	return nil

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -218,17 +218,16 @@ func (p *PostgreSQL) ExtraIndexes(idxs []string) error {
 	for _, v := range idxs {
 		t := fmt.Sprintf("((json->'%s'))", v)
 		name := "json_"
-
-		if strings.Contains(v, "qsa") && !strings.Contains(v, "cnae") {
+		if strings.Contains(v, ".") {
 			v = strings.Split(v, ".")[1]
-			t = fmt.Sprintf("(jsonb_extract_path(json, 'qsa', '%s') jsonb_ops)", v)
-			name += "qsa_"
-		}
-
-		if !strings.Contains(v, "qsa") && strings.Contains(v, "cnae") {
-			v = strings.Split(v, ".")[1]
-			t = fmt.Sprintf("(jsonb_extract_path(json, 'cnaes_secundarios', '%s') jsonb_ops)", v)
-			name += "cnaes_secundarios_"
+			if strings.Contains(v, "qsa") {
+				t = fmt.Sprintf("(jsonb_extract_path(json, 'qsa', '%s') jsonb_ops)", v)
+				name += "qsa_"
+			}
+			if strings.Contains(v, "cnae") {
+				t = fmt.Sprintf("(jsonb_extract_path(json, 'cnaes_secundarios', '%s') jsonb_ops)", v)
+				name += "cnaes_secundarios_"
+			}
 		}
 		q := fmt.Sprintf(
 			"CREATE INDEX IF NOT EXISTS idx_%s%s ON %s USING GIN %s;",

--- a/db/postgres/extra_indexes.sql
+++ b/db/postgres/extra_indexes.sql
@@ -1,1 +1,5 @@
-CREATE INDEX IF NOT EXISTS idx_{{ .IDFieldName }} ON {{ .CompanyTableFullName }} USING GIN ({{ .JSONFieldName }});
+{{- if eq .OptExtraIndexes.Type "root" }}
+CREATE INDEX IF NOT EXISTS idx_{{ .OptExtraIndexes.Name }} ON {{ .CompanyTableFullName }} USING GIN ((json->'{{ .OptExtraIndexes.Value }}'));
+{{- else }}
+CREATE INDEX IF NOT EXISTS idx_{{ .OptExtraIndexes.Name }} ON {{ .CompanyTableFullName }} USING GIN (jsonb_extract_path(json, '{{ .OptExtraIndexes.Type }}', '{{ .OptExtraIndexes.Value }}') jsonb_ops);
+{{- end }}

--- a/db/postgres/extra_indexes.sql
+++ b/db/postgres/extra_indexes.sql
@@ -1,5 +1,7 @@
-{{- if eq .OptExtraIndexes.Type "root" }}
-CREATE INDEX IF NOT EXISTS idx_{{ .OptExtraIndexes.Name }} ON {{ .CompanyTableFullName }} USING GIN ((json->'{{ .OptExtraIndexes.Value }}'));
+{{- if eq .OptExtraIndexes.TypeIdx "root" }}
+CREATE INDEX IF NOT EXISTS idx_{{ .OptExtraIndexes.NameIdx }} ON {{ .CompanyTableFullName }} USING GIN ((json->'{{ .OptExtraIndexes.ValueIdx }}'));
+{{- else if ne .OptExtraIndexes.TypeIdx "root" }}
+CREATE INDEX IF NOT EXISTS idx_{{ .OptExtraIndexes.NameIdx }} ON {{ .CompanyTableFullName }} USING GIN (jsonb_extract_path(json, '{{ .OptExtraIndexes.TypeIdx }}', '{{ .OptExtraIndexes.ValueIdx }}') jsonb_ops);
 {{- else }}
-CREATE INDEX IF NOT EXISTS idx_{{ .OptExtraIndexes.Name }} ON {{ .CompanyTableFullName }} USING GIN (jsonb_extract_path(json, '{{ .OptExtraIndexes.Type }}', '{{ .OptExtraIndexes.Value }}') jsonb_ops);
+
 {{- end }}

--- a/db/postgres/extra_indexes.sql
+++ b/db/postgres/extra_indexes.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_{{ .IDFieldName }} ON {{ .CompanyTableFullName }} USING GIN ({{ .JSONFieldName }});

--- a/db/postgres/extra_indexes.sql
+++ b/db/postgres/extra_indexes.sql
@@ -1,7 +1,5 @@
-{{- if eq .OptExtraIndexes.TypeIdx "root" }}
-CREATE INDEX IF NOT EXISTS idx_{{ .OptExtraIndexes.NameIdx }} ON {{ .CompanyTableFullName }} USING GIN ((json->'{{ .OptExtraIndexes.ValueIdx }}'));
-{{- else if ne .OptExtraIndexes.TypeIdx "root" }}
-CREATE INDEX IF NOT EXISTS idx_{{ .OptExtraIndexes.NameIdx }} ON {{ .CompanyTableFullName }} USING GIN (jsonb_extract_path(json, '{{ .OptExtraIndexes.TypeIdx }}', '{{ .OptExtraIndexes.ValueIdx }}') jsonb_ops);
+{{- if eq .ExtraIndexesFields.Type "root" }}
+CREATE INDEX IF NOT EXISTS idx_{{ .ExtraIndexesFields.Name }} ON {{ .CompanyTableFullName }} USING GIN ((json->'{{ .ExtraIndexesFields.Value }}'));
 {{- else }}
-
+CREATE INDEX IF NOT EXISTS idx_{{ .ExtraIndexesFields.Name }} ON {{ .CompanyTableFullName }} USING GIN (jsonb_extract_path(json, '{{ .ExtraIndexesFields.Type }}', '{{ .ExtraIndexesFields.Value }}') jsonb_ops);
 {{- end }}


### PR DESCRIPTION
Criação dos indices extras via comando `./minha-receita exstra-indexes indice1 indece2 indice3` de acordo com o nome que esta no JSON.

~~Sendo que os estão dentro de QSA e CNAE não precisa por o `qsa` ou `cnae` na frente.~~

Fixes #279 