### PR TITLE
Updates Chunk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 require (
 	github.com/avast/retry-go/v4 v4.6.1
 	github.com/aws/aws-sdk-go v1.55.6
-	github.com/cuducos/chunk v1.1.3
+	github.com/cuducos/chunk v1.1.4
 	github.com/cuducos/go-cnpj v0.1.2
 	github.com/dgraph-io/badger/v4 v4.5.1
 	github.com/jackc/pgx/v5 v5.7.2

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/chengxilo/virtualterm v1.0.4/go.mod h1:DyxxBZz/x1iqJjFxTFcr6/x+jSpqN0
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/cuducos/chunk v1.1.3 h1:DoB2DF2Kj6xLPcDFe+VBBIMv3JfNDGMBbUKgrwmJglY=
-github.com/cuducos/chunk v1.1.3/go.mod h1:MieiCPvKtGwJWcSoHb4HIzC8VtQ2LeH0xzt7d6rYQz0=
+github.com/cuducos/chunk v1.1.4 h1:sJYLHMZP4+dQfgM7Mqo2cjPhCGYKkxLJUJHrbVgJWVg=
+github.com/cuducos/chunk v1.1.4/go.mod h1:MieiCPvKtGwJWcSoHb4HIzC8VtQ2LeH0xzt7d6rYQz0=
 github.com/cuducos/go-cnpj v0.1.2 h1:EKfO9AJPjxBh/Pc8S+SMSeXvQ7kLwhDoF6te4md58OA=
 github.com/cuducos/go-cnpj v0.1.2/go.mod h1:Oe0M530eHl9eXExbNWriqTD9kMv618ScjlGtEey/f4Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Precisamos da versão nova (1.1.4) para lidar com os espaços no nome dos arquivos descritos em #193 