### PR TITLE
Refactora a parte de estabelecimentos do comando `tansform`

### DIFF
--- a/cmd/transform.go
+++ b/cmd/transform.go
@@ -8,9 +8,9 @@ import (
 )
 
 const transformHelper = `
-Convert the CSV files from the Federal Revenue for venues (ESTABELE group of
-files) into records in the database, 1 record per CNPJ, joining information
-from all other source CSV files.
+Convert the CSV files from the Federal Revenue for venues (Estabelecimentos*.zip
+group of files) into records in the database, 1 record per CNPJ, joining
+information from all other source CSV files.
 
 The transformation process is divided into two steps:
 1. Load relational data to a key-value store
@@ -19,6 +19,7 @@ The transformation process is divided into two steps:
 
 var (
 	maxParallelDBQueries int
+	maxParallelKVWrites  int
 	batchSize            int
 	cleanUp              bool
 	noPrivacy            bool
@@ -47,7 +48,7 @@ var transformCmd = &cobra.Command{
 				return err
 			}
 		}
-		return transform.Transform(dir, db, maxParallelDBQueries, batchSize, !noPrivacy)
+		return transform.Transform(dir, db, maxParallelDBQueries, maxParallelKVWrites, batchSize, !noPrivacy)
 	},
 }
 
@@ -60,6 +61,13 @@ func transformCLI() *cobra.Command {
 		"m",
 		transform.MaxParallelDBQueries,
 		"maximum parallel database queries",
+	)
+	transformCmd.Flags().IntVarP(
+		&maxParallelKVWrites,
+		"max-parallel-kv-writes",
+		"k",
+		transform.MaxParallelKVWrites,
+		"the default is optimized for high throughput SATA SSD. Recommended values are between 64 and 128 for HDD, 256 and 1,024 for SSD, and 4,096 and 16,384 for NVMe SSD.",
 	)
 	transformCmd.Flags().IntVarP(&batchSize, "batch-size", "b", transform.BatchSize, "size of the batch to save to the database")
 	transformCmd.Flags().BoolVarP(&cleanUp, "clean-up", "c", cleanUp, "drop & recreate the database table before starting")

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/spf13/cobra v1.9.1
 	go.mongodb.org/mongo-driver v1.17.3
+	golang.org/x/sync v0.14.0
 	golang.org/x/text v0.25.0
 )
 
@@ -46,7 +47,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/sync v0.14.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/term v0.30.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157 // indirect

--- a/transform/badger.go
+++ b/transform/badger.go
@@ -15,33 +15,6 @@ func keyForBase(n string) string        { return fmt.Sprintf("b-%s", n) }
 func keyForSimpleTaxes(n string) string { return fmt.Sprintf("st-%s", n) }
 func keyForTaxRegime(n string) string   { return fmt.Sprintf("tr-%s", cnpj.Unmask(n)) }
 
-// functions to read data from Badger
-
-func partnersOf(db *badger.DB, n string) ([]PartnerData, error) {
-	p := []PartnerData{}
-	err := db.View(func(txn *badger.Txn) error {
-		i, err := txn.Get([]byte(keyForPartners(n)))
-		if errors.Is(err, badger.ErrKeyNotFound) {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("could not get key %s: %w", keyForPartners(n), err)
-		}
-		v, err := i.ValueCopy(nil)
-		if err != nil {
-			return fmt.Errorf("could not read value for key %s: %w", keyForPartners(n), err)
-		}
-		if err := json.Unmarshal(v, &p); err != nil {
-			return fmt.Errorf("could not parse partners: %w", err)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error getting partners for %s: %w", n, err)
-	}
-	return p, nil
-}
-
 func baseOf(db *badger.DB, n string) (baseData, error) {
 	var d baseData
 	err := db.View(func(txn *badger.Txn) error {
@@ -93,119 +66,52 @@ func simpleTaxesOf(db *badger.DB, n string) (simpleTaxesData, error) {
 }
 
 func taxRegimeOf(db *badger.DB, n string) (TaxRegimes, error) {
-	var d TaxRegimes
-	err := db.View(func(txn *badger.Txn) error {
-		i, err := txn.Get([]byte(keyForTaxRegime(n)))
-		if errors.Is(err, badger.ErrKeyNotFound) {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("could not get key %s: %w", keyForSimpleTaxes(n), err)
-		}
-		v, err := i.ValueCopy(nil)
-		if err != nil {
-			return fmt.Errorf("could not read value for key %s: %w", keyForSimpleTaxes(n), err)
-		}
-		if err := json.Unmarshal(v, &d); err != nil {
-			return fmt.Errorf("could not parse taxes: %w", err)
-		}
-		return nil
-	})
-	if err != nil {
-		return TaxRegimes{}, fmt.Errorf("error getting tax regimes for %s: %w", n, err)
-	}
-	sort.Sort(TaxRegimes(d))
-	return d, nil
-}
-
-// functions to write data to Badger
-
-func mergePartners(db *badger.DB, k, b []byte) ([]byte, error) {
-	curr := []byte("[]")
-	err := db.View(func(tx *badger.Txn) error {
-		i, err := tx.Get(k)
-		if errors.Is(err, badger.ErrKeyNotFound) {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("error getting partner key: %w", err)
-		}
-		curr, err = i.ValueCopy(nil)
-		if err != nil {
-			return fmt.Errorf("error reading partner value: %w", err)
+	var ts TaxRegimes
+	pre := []byte(keyForTaxRegime(n))
+	db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		defer it.Close()
+		for it.Seek(pre); it.ValidForPrefix(pre); it.Next() {
+			var t TaxRegime
+			i := it.Item()
+			err := i.Value(func(v []byte) error {
+				if err := json.Unmarshal(v, &t); err != nil {
+					return fmt.Errorf("could not parse tax regime: %w", err)
+				}
+				ts = append(ts, t)
+				return nil
+			})
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})
-	if err != nil {
-		return nil, fmt.Errorf("error getting current partners: %w", err)
-	}
-	qsa := []PartnerData{}
-	if curr != nil {
-		if err := json.Unmarshal(curr, &qsa); err != nil {
-			return nil, fmt.Errorf("could not parse partners: %w", err)
-		}
-	}
-	var p PartnerData
-	if err := json.Unmarshal(b, &p); err != nil {
-		return nil, fmt.Errorf("could not parse partner: %w", err)
-	}
-	qsa = append(qsa, p)
-	j, err := json.Marshal(&qsa)
-	if err != nil {
-		return nil, fmt.Errorf("could not convert partner to json: %w", err)
-	}
-	return j, nil
+	sort.Sort(TaxRegimes(ts))
+	return ts, nil
 }
 
-func mergeTaxRegimes(db *badger.DB, k, b []byte) ([]byte, error) {
-	curr := []byte("[]")
-	err := db.View(func(tx *badger.Txn) error {
-		i, err := tx.Get(k)
-		if errors.Is(err, badger.ErrKeyNotFound) {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("error getting tax regime key: %w", err)
-		}
-		curr, err = i.ValueCopy(nil)
-		if err != nil {
-			return fmt.Errorf("error reading tax regime value: %w", err)
+func partnersOf(db *badger.DB, n string) ([]PartnerData, error) {
+	var ps []PartnerData
+	pre := []byte(keyForPartners(n))
+	db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		defer it.Close()
+		for it.Seek(pre); it.ValidForPrefix(pre); it.Next() {
+			var p PartnerData
+			i := it.Item()
+			err := i.Value(func(v []byte) error {
+				if err := json.Unmarshal(v, &p); err != nil {
+					return fmt.Errorf("could not parse parter: %w", err)
+				}
+				ps = append(ps, p)
+				return nil
+			})
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})
-	if err != nil {
-		return nil, fmt.Errorf("error getting current tax regimes: %w", err)
-	}
-	ts := TaxRegimes{}
-	if curr != nil {
-		if err := json.Unmarshal(curr, &ts); err != nil {
-			return nil, fmt.Errorf("could not parse tax regimes: %w", err)
-		}
-	}
-	var t TaxRegime
-	if err := json.Unmarshal(b, &t); err != nil {
-		return nil, fmt.Errorf("could not parse tax regime: %w", err)
-	}
-	ts = append(ts, t)
-	j, err := json.Marshal(&ts)
-	if err != nil {
-		return nil, fmt.Errorf("could not convert tax regime to json: %w", err)
-	}
-	return j, nil
-}
-
-func saveItem(db *badger.DB, s sourceType, k, v []byte) (err error) {
-	if s == partners {
-		v, err = mergePartners(db, k, v)
-		if err != nil {
-			return fmt.Errorf("error merging partners: %w", err)
-		}
-	}
-	if s == realProfit || s == presumedProfit || s == arbitratedProfit || s == noTaxes {
-		v, err = mergeTaxRegimes(db, k, v)
-		if err != nil {
-			return fmt.Errorf("error merging taxes: %w", err)
-		}
-	}
-	return db.Update(func(tx *badger.Txn) error { return tx.Set(k, v) })
+	return ps, nil
 }

--- a/transform/badger_test.go
+++ b/transform/badger_test.go
@@ -2,7 +2,6 @@ package transform
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -20,60 +19,6 @@ func newTestBadgerDB(t *testing.T) *badger.DB {
 	return db
 }
 
-var (
-	testIdentificacaoDoSocio1                 = 1
-	testCodigoQualificacaoSocio1              = 2
-	testQualificacaoSocio1                    = "Dois"
-	testCodigoPais1                           = 3
-	testPais1                                 = "Três"
-	testCodigoQualificacaoRepresentanteLegal1 = 4
-	testQualificacaoRepresentanteLegal1       = "Quatro"
-	testCodigoFaixaEtaria1                    = 5
-	testFaixaEtarua1                          = "Cinco"
-	testPartner1                              = PartnerData{
-		&testIdentificacaoDoSocio1,
-		"Nome da pessoa 1",
-		"123",
-		&testCodigoQualificacaoSocio1,
-		&testQualificacaoSocio1,
-		nil,
-		&testCodigoPais1,
-		&testPais1,
-		"456",
-		"Representante legal 1",
-		&testCodigoQualificacaoRepresentanteLegal1,
-		&testQualificacaoRepresentanteLegal1,
-		&testCodigoFaixaEtaria1,
-		&testFaixaEtarua1,
-	}
-
-	testIdentificacaoDoSocio2                 = 6
-	testCodigoQualificacaoSocio2              = 7
-	testQualificacaoSocio2                    = "Sete"
-	testCodigoPais2                           = 8
-	testPais2                                 = "Oito"
-	testCodigoQualificacaoRepresentanteLegal2 = 9
-	testQualificacaoRepresentanteLegal2       = "Nove"
-	testCodigoFaixaEtaria2                    = 10
-	testFaixaEtarua2                          = "Dez"
-	testPartner2                              = PartnerData{
-		&testIdentificacaoDoSocio2,
-		"Nome da pessoa 2",
-		"789",
-		&testCodigoQualificacaoSocio2,
-		&testQualificacaoSocio2,
-		nil,
-		&testCodigoPais2,
-		&testPais2,
-		"012",
-		"Representante legal 2",
-		&testCodigoQualificacaoRepresentanteLegal2,
-		&testQualificacaoRepresentanteLegal2,
-		&testCodigoFaixaEtaria2,
-		&testFaixaEtarua2,
-	}
-)
-
 func toBytes(t *testing.T, i any) []byte {
 	b, err := json.Marshal(i)
 	if err != nil {
@@ -82,56 +27,18 @@ func toBytes(t *testing.T, i any) []byte {
 	return b
 }
 
-func TestMergePartners(t *testing.T) {
-	k := []byte(testBaseCNPJ)
-	p := newTestPartner()
-	v := toBytes(t, p)
-	for _, tc := range []struct {
-		existing []PartnerData
-		expected []PartnerData
-	}{
-		{nil, []PartnerData{p}},
-		{[]PartnerData{testPartner1}, []PartnerData{testPartner1, p}},
-		{[]PartnerData{testPartner1, testPartner2}, []PartnerData{testPartner1, testPartner2, p}},
-	} {
-		t.Run(fmt.Sprintf("merging to %d partners", len(tc.existing)), func(t *testing.T) {
-			db := newTestBadgerDB(t)
-			defer db.Close()
-			if tc.existing != nil {
-				db.Update(func(tx *badger.Txn) error {
-					if err := tx.Set(k, toBytes(t, tc.existing)); err != nil {
-						t.Fatalf("error setting existing partners %v: %s", tc.existing, err)
-					}
-					return nil
-				})
-			}
-			m, err := mergePartners(db, k, v)
-			if err != nil {
-				t.Errorf("expected no error merging partners, got %s", err)
-			}
-			var got []PartnerData
-			if err := json.Unmarshal(m, &got); err != nil {
-				t.Errorf("could not parse merged partners: %s", err)
-			}
-			if !reflect.DeepEqual(got, tc.expected) {
-				t.Errorf("expected merged partners to be %v, got %v", tc.expected, got)
-			}
-		})
-	}
-
+func saveItem(t *testing.T, db *badger.DB, k string, v any) error {
+	return db.Update(func(tx *badger.Txn) error {
+		return tx.Set([]byte(k), toBytes(t, v))
+	})
 }
 
-func TestSaveAndReadItems(t *testing.T) {
+func TestReadItems(t *testing.T) {
 	t.Run("partners", func(t *testing.T) {
 		p := newTestPartner()
 		db := newTestBadgerDB(t)
 		defer db.Close()
-		err := saveItem(
-			db, partners,
-			[]byte(keyForPartners(testBaseCNPJ)),
-			toBytes(t, p),
-		)
-		if err != nil {
+		if err := saveItem(t, db, keyForPartners(testBaseCNPJ)+":md5hash", p); err != nil {
 			t.Errorf("expected no error saving partner, got %s", err)
 		}
 		got, err := partnersOf(db, testBaseCNPJ)
@@ -139,7 +46,7 @@ func TestSaveAndReadItems(t *testing.T) {
 			t.Errorf("expected no error reading partners, got %s", err)
 		}
 		if len(got) != 1 {
-			t.Errorf("expected merged partnes to have 1 partger, got %d", len(got))
+			t.Errorf("expected merged partners to have 1 partner, got %d", len(got))
 			return
 		}
 		if !reflect.DeepEqual(got[0], p) {
@@ -151,9 +58,7 @@ func TestSaveAndReadItems(t *testing.T) {
 		db := newTestBadgerDB(t)
 		defer db.Close()
 		d := newTestBaseCNPJ()
-		v := toBytes(t, d)
-		err := saveItem(db, base, []byte(keyForBase(testBaseCNPJ)), v)
-		if err != nil {
+		if err := saveItem(t, db, keyForBase(testBaseCNPJ), d); err != nil {
 			t.Errorf("expected no error saving partner, got %s", err)
 		}
 		got, err := baseOf(db, testBaseCNPJ)
@@ -169,9 +74,7 @@ func TestSaveAndReadItems(t *testing.T) {
 		db := newTestBadgerDB(t)
 		defer db.Close()
 		d := newTestTaxes()
-		v := toBytes(t, d)
-		err := saveItem(db, simpleTaxes, []byte(keyForSimpleTaxes(testBaseCNPJ)), v)
-		if err != nil {
+		if err := saveItem(t, db, keyForSimpleTaxes(testBaseCNPJ), d); err != nil {
 			t.Errorf("expected no error saving partner, got %s", err)
 		}
 		got, err := simpleTaxesOf(db, testBaseCNPJ)

--- a/transform/company.go
+++ b/transform/company.go
@@ -117,6 +117,9 @@ func (c *Company) identificadorMatrizFilial(v string) error {
 
 func newCompany(row []string, l *lookups, kv kvStorage, privacy bool) (Company, error) {
 	var c Company
+	if len(row) != 30 {
+		return c, fmt.Errorf("invalid row with %d columns (expected 30): %v", len(row), row)
+	}
 	c.CNPJ = row[0] + row[1] + row[2]
 	c.NomeFantasia = row[4]
 	c.NomeCidadeNoExterior = row[8]

--- a/transform/company_test.go
+++ b/transform/company_test.go
@@ -124,7 +124,7 @@ func TestNewCompany(t *testing.T) {
 		if err != nil {
 			t.Errorf("expected no errors creating look up tables, got %v", err)
 		}
-		if err := kv.load(testdata, &lookups); err != nil {
+		if err := kv.load(testdata, &lookups, 1024); err != nil {
 			t.Errorf("expected no error loading values to badger, got %s", err)
 		}
 		got, err := newCompany(row, &lookups, kv, true)
@@ -280,7 +280,7 @@ func TestNewCompany(t *testing.T) {
 		if err != nil {
 			t.Errorf("expected no errors creating look up tables, got %v", err)
 		}
-		if err := kv.load(testdata, &lookups); err != nil {
+		if err := kv.load(testdata, &lookups, 1024); err != nil {
 			t.Errorf("expected no error loading values to badger, got %s", err)
 		}
 		email := "serpro@serpro.gov.br"

--- a/transform/taxes_test.go
+++ b/transform/taxes_test.go
@@ -14,17 +14,15 @@ func newTestTaxes() simpleTaxesData {
 	return simpleTaxesData{&simples, &dtSimples, nil, &mei, &inMEI, &outMEI}
 }
 
-var (
-	simpleTaxesCSVRow = []string{
-		"BASE DO CNPJ",
-		"S",        // OpcaoPeloSimples
-		"20221217", // DataOpcaoPeloSimples
-		"",         // DataExclusaoDoSimples
-		"N",        // OpcaoPeloMEI
-		"20221118", // DataOpcaoPeloMEI
-		"20221201", // DataExclusaoDoMEI
-	}
-)
+var simpleTaxesCSVRow = []string{
+	"BASE DO CNPJ",
+	"S",        // OpcaoPeloSimples
+	"20221217", // DataOpcaoPeloSimples
+	"",         // DataExclusaoDoSimples
+	"N",        // OpcaoPeloMEI
+	"20221118", // DataOpcaoPeloMEI
+	"20221201", // DataExclusaoDoMEI
+}
 
 func TestNewTaxes(t *testing.T) {
 	d, err := newSimpleTaxesData(simpleTaxesCSVRow)

--- a/transform/venues_test.go
+++ b/transform/venues_test.go
@@ -23,7 +23,7 @@ func TestTaskRun(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no errors creating look up tables, got %v", err)
 	}
-	if err := kv.load(testdata, &lookups); err != nil {
+	if err := kv.load(testdata, &lookups, 1024); err != nil {
 		t.Errorf("expected no error loading values to badger, got %s", err)
 	}
 	r, err := createJSONRecordsTask(testdata, db, &lookups, kv, 2, false)


### PR DESCRIPTION
É frequente ter um `panic: send on closed channel` no `venuesTask` mascarando a verdadeira causa do erro (por exemplo, ver #146, #175, #185, #189, #223, #302, #327). 

Esse refactor tem como objetivo melhorar o gerenciamento das _gorotinas_ concorrentes para tentar evitar tantos `panic: send on closed channel`.

### Principais mudanças

- Elimina estruturas de controle como `shutdown` e `sentToBatches` para fechar os canais
- Ao invés de um único _wait group_, adota uma para as _gorotinas_ produzindo dados, e outro para as consumindo dados
- Utiliza esses _wait groups_ separados para saber quando fechar canais que os produtores e consumidores utilizam
- Utiliza contexto (com função de cancelar) para propagar encerramento para _gorotinas_ existentes

### Contexto

* Uma `source` é um leitor de vários arquivos — são dez arquivos `Estabelecimentos*.zip`, cada um contendo um CSV
* As _gorotinas_ que produzem dadosfazem a leitura desses dez arquivos concorrentemente, enviando as linhas do CSV (`[]stirng`) para um canal
* As _gorotinas_ que consomem essas linhas de CSV, transformam essas linhas em dados estruturados (`Company`) e chamam uma função que salva esses dados no banco (`saveBatch`)
    * Existem várias _gorotinas_ consumindo concorrentemente o canal de linhas dos CSVs