### PR TITLE
bugfix das datas estavam vindo todas 0001-01-01

### DIFF
--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -92,7 +92,7 @@ func (m *MongoDB) CreateCompanies(batch [][]string) error {
 		return fmt.Errorf("mongodb connection not initialized")
 	}
 	coll := m.db.Collection(companyTableName)
-	var cs interface{} // required by MongoDb pkg
+	var cs []interface{} // required by MongoDb pkg
 	for _, c := range batch {
 		if len(c) < 2 {
 			return fmt.Errorf("line skipped due to insufficient length: %s", c)
@@ -103,11 +103,13 @@ func (m *MongoDB) CreateCompanies(batch [][]string) error {
 		if err != nil {
 			return fmt.Errorf("error deserializing JSON: %s\nerror: %w", c[1], err)
 		}
-		cs = r
+		cs = append(cs, r)
+	}
+	if len(cs) > 0 {
 		ctx := context.Background()
-		_, err = coll.InsertOne(ctx, cs)
+		_, err := coll.InsertMany(ctx, cs)
 		if err != nil {
-			log.Fatal(err)
+			return fmt.Errorf("error inserting companies into MongoDB: %w", err)
 		}
 	}
 	return nil

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -92,7 +92,7 @@ func (m *MongoDB) CreateCompanies(batch [][]string) error {
 		return fmt.Errorf("mongodb connection not initialized")
 	}
 	coll := m.db.Collection(companyTableName)
-	var cs []interface{} // required by MongoDb pkg
+	var cs interface{} // required by MongoDb pkg
 	for _, c := range batch {
 		if len(c) < 2 {
 			return fmt.Errorf("line skipped due to insufficient length: %s", c)
@@ -103,15 +103,12 @@ func (m *MongoDB) CreateCompanies(batch [][]string) error {
 		if err != nil {
 			return fmt.Errorf("error deserializing JSON: %s\nerror: %w", c[1], err)
 		}
-		cs = append(cs, r)
-	}
-	if len(cs) == 0 {
-		return nil
-	}
-	ctx := context.Background()
-	_, err := coll.InsertMany(ctx, cs)
-	if err != nil {
-		return fmt.Errorf("error inserting companies into MongoDB: %w", err)
+		cs = r
+		ctx := context.Background()
+		_, err = coll.InsertOne(ctx, cs)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 	return nil
 }

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -105,12 +105,13 @@ func (m *MongoDB) CreateCompanies(batch [][]string) error {
 		}
 		cs = append(cs, r)
 	}
-	if len(cs) > 0 {
-		ctx := context.Background()
-		_, err := coll.InsertMany(ctx, cs)
-		if err != nil {
-			return fmt.Errorf("error inserting companies into MongoDB: %w", err)
-		}
+	if len(cs) == 0 {
+		return nil
+	}
+	ctx := context.Background()
+	_, err := coll.InsertMany(ctx, cs)
+	if err != nil {
+		return fmt.Errorf("error inserting companies into MongoDB: %w", err)
 	}
 	return nil
 }

--- a/transform/cast.go
+++ b/transform/cast.go
@@ -91,31 +91,31 @@ func (d date) MarshalBSONValue() (bsontype.Type, []byte, error) {
 	return bson.TypeString, bsoncore.AppendString(nil, t.Format(dateOutputFormat)), nil
 }
 
-func (d *date) UnmarshalBSONValue(t bsontype.Type, data []byte) error {
+func (d *date) UnmarshalBSONValue(t bsontype.Type, v []byte) error {
 	switch t {
 	case bson.TypeString:
-		str, _, ok := bsoncore.ReadString(data)
+		s, _, ok := bsoncore.ReadString(v)
 		if !ok {
-			return fmt.Errorf("invalid BSON string")
+			return fmt.Errorf("invalid bson string")
 		}
-		if str == "" {
+		if s == "" {
 			return nil
 		}
-		p, err := time.Parse(dateOutputFormat, str)
+		p, err := time.Parse(dateOutputFormat, s)
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid date parse: %s", err)
 		}
 		*d = date(p)
 		return nil
 	case bson.TypeDateTime:
-		ms, _, ok := bsoncore.ReadDateTime(data)
+		i, _, ok := bsoncore.ReadDateTime(v)
 		if !ok {
-			return fmt.Errorf("invalid BSON datetime")
+			return fmt.Errorf("invalid bson datetime")
 		}
-		*d = date(time.UnixMilli(ms))
+		*d = date(time.UnixMilli(i))
 		return nil
 	default:
-		return fmt.Errorf("unsupported BSON type for date: %v", t)
+		return fmt.Errorf("unsupported bson type for date: %v", t)
 	}
 }
 

--- a/transform/cast.go
+++ b/transform/cast.go
@@ -86,13 +86,11 @@ func (d *date) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + t.Format(dateOutputFormat) + `"`), nil
 }
 
-// MarshalBSONValue implementa a serialização para o MongoDB
 func (d date) MarshalBSONValue() (bsontype.Type, []byte, error) {
 	t := time.Time(d)
 	return bson.TypeString, bsoncore.AppendString(nil, t.Format(dateOutputFormat)), nil
 }
 
-// UnmarshalBSONValue implementa a desserialização para o MongoDB
 func (d *date) UnmarshalBSONValue(t bsontype.Type, data []byte) error {
 	var tm time.Time
 	err := bson.UnmarshalValue(t, data, &tm)

--- a/transform/cast.go
+++ b/transform/cast.go
@@ -18,6 +18,10 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 const (
@@ -80,6 +84,23 @@ func (d *date) UnmarshalJSON(b []byte) error {
 func (d *date) MarshalJSON() ([]byte, error) {
 	t := time.Time(*d)
 	return []byte(`"` + t.Format(dateOutputFormat) + `"`), nil
+}
+
+// MarshalBSONValue implementa a serialização para o MongoDB
+func (d date) MarshalBSONValue() (bsontype.Type, []byte, error) {
+	t := time.Time(d)
+	return bson.TypeString, bsoncore.AppendString(nil, t.Format(dateOutputFormat)), nil
+}
+
+// UnmarshalBSONValue implementa a desserialização para o MongoDB
+func (d *date) UnmarshalBSONValue(t bsontype.Type, data []byte) error {
+	var tm time.Time
+	err := bson.UnmarshalValue(t, data, &tm)
+	if err != nil {
+		return err
+	}
+	*d = date(tm)
+	return nil
 }
 
 // toDate expects a date as string in the format YYYYMMDD (that is the format


### PR DESCRIPTION
As datas estavam vindo todas 0001-01-01, identifiquei que o Marshal deveria ser tratado via BSON tambem. 

algo ocorreu, no meu Mongo do mes 4, as datas estavam corretas, possivelmente depois de adicionarmos o BSON no extra-indexes, que ele começou a usar o BSON de fato porem nao tinha tratativa no date para tal.

Com isso fiz as seguintes mudanças a mesma funcionou no SAMPLE e estou realizando a importacao do banco full. para dar OK 

