### PR TITLE
Busca apenas por cnpf não funciona

### DIFF
--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -241,18 +241,18 @@ func (m *MongoDB) Search(ctx context.Context, q *Query) (string, error) {
 	if len(q.CNAE) > 0 {
 		if len(q.CNAE) == 1 {
 			f["$or"] = []bson.M{
-				{"cnae_fiscal": q.CNAE[0]},
-				{"cnaes_secundarios.codigo": bson.M{"$in": q.CNAE}},
+				{"json.cnae_fiscal": q.CNAE[0]},
+				{"json.cnaes_secundarios.codigo": bson.M{"$in": q.CNAE}},
 			}
 		} else {
 			f["$or"] = []bson.M{
-				{"cnae_fiscal": bson.M{"$in": q.CNAE}},
-				{"cnaes_secundarios.codigo": bson.M{"$in": q.CNAE}},
+				{"json.cnae_fiscal": bson.M{"$in": q.CNAE}},
+				{"json.cnaes_secundarios.codigo": bson.M{"$in": q.CNAE}},
 			}
 		}
 	}
 	if len(q.CNPF) > 0 {
-		f["qsa.cnpj_cpf_do_socio"] = bson.M{"$in": q.CNPF}
+		f["json.qsa.cnpj_cpf_do_socio"] = bson.M{"$in": q.CNPF}
 	}
 	if q.Cursor != nil {
 		f["id"] = bson.M{"$gt": *q.Cursor}

--- a/db/pagination.go
+++ b/db/pagination.go
@@ -28,16 +28,16 @@ func parseURLParams(q []string) []string {
 }
 
 func parseURLParamsToUInt(q []string) []uint32 {
-    var r []uint32
-    for _, v := range parseURLParams(q) {
-        n, err := strconv.Atoi(v)
-        if err != nil || n <= 0 {
-            slog.Info("Ignoring invalid CNAE number", "cnae", v)
-            continue
-        }
-        r = append(r, uint32(n))
-    }
-    return r
+	var r []uint32
+	for _, v := range parseURLParams(q) {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			slog.Info("Ignoring invalid CNAE number", "cnae", v)
+			continue
+		}
+		r = append(r, uint32(n))
+	}
+	return r
 }
 
 type Query struct {

--- a/db/pagination.go
+++ b/db/pagination.go
@@ -27,26 +27,26 @@ func parseURLParams(q []string) []string {
 	return r
 }
 
-func parseURLParamsToUInt(q []string) []uint16 {
-	var r []uint16
-	for _, v := range parseURLParams(q) {
-		n, err := strconv.Atoi(v)
-		if err != nil || n <= 0 {
-			slog.Info("Ignoring invalid CNAE number", "cnae", v)
-			continue
-		}
-		r = append(r, uint16(n))
-	}
-	return r
+func parseURLParamsToUInt(q []string) []uint32 {
+    var r []uint32
+    for _, v := range parseURLParams(q) {
+        n, err := strconv.Atoi(v)
+        if err != nil || n <= 0 {
+            slog.Info("Ignoring invalid CNAE number", "cnae", v)
+            continue
+        }
+        r = append(r, uint32(n))
+    }
+    return r
 }
 
 type Query struct {
 	UF         []string
 	CNPF       []string // CNPJ or CPF in the QSA
-	CNAE       []uint16
-	CNAEFiscal []uint16
+	CNAE       []uint32
+	CNAEFiscal []uint32
 	Cursor     *string
-	Limit      uint16
+	Limit      uint32
 }
 
 func (q *Query) Empty() bool {


### PR DESCRIPTION
#352 
Acontece que a struct Query estava usando uint16 e o parse erroneamente estava recebendo por exemplo:

8211300 e no mongo chegando 19300

alterei o parse e a struct para uint32, e o mongo esta recebendo o cnae corretamente.