### PR TITLE
Correção do tipo uint16 para uint32 do CNAE

### DIFF
--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -241,13 +241,13 @@ func (m *MongoDB) Search(ctx context.Context, q *Query) (string, error) {
 	if len(q.CNAE) > 0 {
 		if len(q.CNAE) == 1 {
 			f["$or"] = []bson.M{
-				{"cnae_fiscal": q.CNAE[0]},
-				{"cnaes_secundarios.codigo": bson.M{"$in": q.CNAE}},
+				{"json.cnae_fiscal": q.CNAE[0]},
+				{"json.cnaes_secundarios.codigo": bson.M{"$in": q.CNAE}},
 			}
 		} else {
 			f["$or"] = []bson.M{
-				{"cnae_fiscal": bson.M{"$in": q.CNAE}},
-				{"cnaes_secundarios.codigo": bson.M{"$in": q.CNAE}},
+				{"json.cnae_fiscal": bson.M{"$in": q.CNAE}},
+				{"json.cnaes_secundarios.codigo": bson.M{"$in": q.CNAE}},
 			}
 		}
 	}

--- a/db/pagination.go
+++ b/db/pagination.go
@@ -27,15 +27,15 @@ func parseURLParams(q []string) []string {
 	return r
 }
 
-func parseURLParamsToUInt(q []string) []uint16 {
-	var r []uint16
+func parseURLParamsToUInt(q []string) []uint32 {
+	var r []uint32
 	for _, v := range parseURLParams(q) {
 		n, err := strconv.Atoi(v)
 		if err != nil || n <= 0 {
 			slog.Info("Ignoring invalid CNAE number", "cnae", v)
 			continue
 		}
-		r = append(r, uint16(n))
+		r = append(r, uint32(n))
 	}
 	return r
 }
@@ -43,10 +43,10 @@ func parseURLParamsToUInt(q []string) []uint16 {
 type Query struct {
 	UF         []string
 	CNPF       []string // CNPJ or CPF in the QSA
-	CNAE       []uint16
-	CNAEFiscal []uint16
+	CNAE       []uint32
+	CNAEFiscal []uint32
 	Cursor     *string
-	Limit      uint16
+	Limit      uint32
 }
 
 func (q *Query) Empty() bool {


### PR DESCRIPTION
A busca por cnae, estava funcionando quando era colocado um CNAE menor que 131072, ou entao, quando era colocado um maior, convertia para HEX e depois o parse convertia para um numero menor.

#357 