### PR TITLE
Evita serializar/deserializar JSON nas consultas web

### DIFF
--- a/db/mongodb_test.go
+++ b/db/mongodb_test.go
@@ -95,26 +95,26 @@ func TestMongoDB(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error querying %#v, got %s", q, err)
 	}
-	var r page
-	if err := json.Unmarshal([]byte(sr), &r); err != nil {
-		t.Errorf("expected error deserializing JSON, got %s", err)
+	var p page
+	if err := json.Unmarshal([]byte(sr), &p); err != nil {
+		t.Errorf("expected error deserializing JSON %s, got %s", sr, err)
 	}
-	if len(r.Data) != 0 {
-		t.Errorf("expected error no result, got %#v", r)
+	if len(p.Data) != 0 {
+		t.Errorf("expected error no result, got %#v", p)
 	}
 	q.UF = []string{"SP"}
 	sr, err = db.Search(context.Background(), &q)
 	if err != nil {
 		t.Errorf("expected no error querying %#v, got %s", q, err)
 	}
-	if err := json.Unmarshal([]byte(sr), &r); err != nil {
-		t.Errorf("expected error deserializing JSON, got %s", err)
+	if err := json.Unmarshal([]byte(sr), &p); err != nil {
+		t.Errorf("expected no error deserializing JSON %s, got %s", sr, err)
 	}
-	if len(r.Data) != 1 {
-		t.Errorf("expected one result, got %d", len(r.Data))
+	if len(p.Data) != 1 {
+		t.Errorf("expected one result, got %d", len(p.Data))
 	}
-	if r.Data[0].UF != "SP" {
-		t.Errorf("expected query result to be from SP, got %s", r.Data[0].UF)
+	if p.Data[0].UF != "SP" {
+		t.Errorf("expected query result to be from SP, got %s", p.Data[0].UF)
 	}
 	metadata, err := db.MetaRead("answer")
 	if err != nil {

--- a/db/pagination.go
+++ b/db/pagination.go
@@ -1,12 +1,11 @@
 package db
 
 import (
+	"fmt"
 	"log/slog"
 	"net/url"
 	"strconv"
 	"strings"
-
-	"github.com/cuducos/minha-receita/transform"
 )
 
 const (
@@ -92,20 +91,15 @@ func NewQuery(v url.Values) *Query {
 	return &q
 }
 
-type page struct {
-	Data   []transform.Company `json:"data" bson:"data"`
-	Cursor *string             `json:"cursor" bson:"cursor"`
-}
-
-func newPage(cs []transform.Company, l uint32, c string) page {
-	var p page
-	if len(cs) > 0 {
-		p.Data = cs
+// builds a paginated search JSON response without depending on marshalling and
+// unmarhsalling results from the database (the assumption for performance is
+// that data coming from the database is valid JSON text).
+func newPage(d []string, l uint32, c string) string {
+	ps := []string{fmt.Sprintf(`"data":[%s]`, strings.Join(d, ","))}
+	if c != "" {
+		ps = append(ps, fmt.Sprintf(`"cursor":"%s"`, c))
 	} else {
-		p.Data = []transform.Company{}
+		ps = append(ps, `"cursor":null`)
 	}
-	if c != "" && len(cs) == int(l) {
-		p.Cursor = &c
-	}
-	return p
+	return fmt.Sprintf(`{%s}`, strings.Join(ps, ","))
 }

--- a/db/postgres_test.go
+++ b/db/postgres_test.go
@@ -10,9 +10,15 @@ import (
 	"testing"
 
 	"github.com/cuducos/minha-receita/testutils"
+	"github.com/cuducos/minha-receita/transform"
 )
 
 var postgresDefaultIndexes = []string{"cnpj_pkey", "cnpj_id"}
+
+type page struct {
+	Data   []transform.Company `json:"data"`
+	Cursor *string             `json:"cursor"`
+}
 
 func listIndexesPostgres(t *testing.T, pg *PostgreSQL) []string {
 	q := `
@@ -95,7 +101,7 @@ func TestPostgresDB(t *testing.T) {
 	}
 	var r page
 	if err := json.Unmarshal([]byte(sr), &r); err != nil {
-		t.Errorf("expected error deserializing JSON, got %s", err)
+		t.Errorf("expected no error deserializing JSON, got %s", err)
 	}
 	if len(r.Data) != 0 {
 		t.Errorf("expected error no result, got %#v", r)
@@ -106,7 +112,7 @@ func TestPostgresDB(t *testing.T) {
 		t.Errorf("expected no error querying %#v, got %s", q, err)
 	}
 	if err := json.Unmarshal([]byte(sr), &r); err != nil {
-		t.Errorf("expected error deserializing JSON, got %s", err)
+		t.Errorf("expected no error deserializing JSON, got %s", err)
 	}
 	if len(r.Data) != 1 {
 		t.Errorf("expected one result, got %d", len(r.Data))

--- a/db/testutils.go
+++ b/db/testutils.go
@@ -19,6 +19,6 @@ func assertCompaniesAreEqual(t *testing.T, s1 string, s2 string) {
 	c1 := toCompany(s1)
 	c2 := toCompany(s2)
 	if !reflect.DeepEqual(c1, c2) {
-		t.Errorf("expected companies to be equal, got %v and %v", c1, c2)
+		t.Errorf("expected companies to be equal, got %s and %s", s1, s2)
 	}
 }


### PR DESCRIPTION
A proposta de alta disponibilidade do projeto tem base na premissa de que o que é armazenado é a resposta esperada pela API web, isso garante a performance. Esse PR adota esse conceito na buscas paginada no Postgres, na busca por CNPJ no Mongo e na busca paginada do Mongo.

Fixes #364
