### PR TITLE
Carrega os dados dos CSVs no Badger

### DIFF
--- a/transformnext/sources.go
+++ b/transformnext/sources.go
@@ -11,22 +11,24 @@ type source struct {
 	sep          rune
 	hasHeader    bool
 	isCumulative bool
-
-	// for accumulative keys
-	counter atomic.Uint32
-
-	// progress tracker
-	total atomic.Int64
-	done  atomic.Int64
+	counter      atomic.Uint32
 }
 
 func (s *source) keyFor(id string) []byte {
 	k := strings.ToLower(strings.TrimPrefix(s.prefix, "Lucro ")[0:3])
 	if !s.isCumulative {
-		return []byte(fmt.Sprintf("%s::%s", id, k))
+		return fmt.Appendf([]byte{}, "%s::%s", id, k)
 	}
 	c := s.counter.Add(1)
-	return []byte(fmt.Sprintf("%s::%s::%d", id, k, c))
+	return fmt.Appendf([]byte{}, "%s::%s::%d", id, k, c)
+}
+
+func (s *source) keyPrefixFor(id string) []byte {
+	if !s.isCumulative {
+		return s.keyFor(id)
+	}
+	k := strings.ToLower(strings.TrimPrefix(s.prefix, "Lucro ")[0:3])
+	return fmt.Appendf([]byte{}, "%s::%s", id, k)
 }
 
 func newSource(prefix string, sep rune, hasHeader, isCumulative bool) *source {


### PR DESCRIPTION
No contexto do refatoração #426, esse PR escreve os dados dos CSVs (qie já estavam sendo lidos) no Badger (armazenamento chave-valor). Para tanto:

- corrige um bug no método de desserializar
- implementa a busca por prefixo no armazenamento de chave-valor
- faz o leitor de CSV receber uma referência do armazenamento de chave-valor para salvar os dados
- para fazer a barra de progresso funcionar, implementa um leitor de CSV que informa quantos bytes foram lidos

Aparentemente essa etapa ficou 4x mais rápida do que no ETL atual : )

```
[Step 1 of 2] Loading data to key-value storage 99% |█████████████████ | 11/11 GB 4.2 MB/s 29m2s
```

(Isso com a base completa de 2025/11.)
