### PR TITLE
Cria o comando `cleanup`

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -110,6 +110,7 @@ func CLI() *cobra.Command {
 	)
 	if os.Getenv("DEBUG") != "" {
 		rootCmd.AddCommand(addDataDir(transformNextCmd))
+		rootCmd.AddCommand(addDataDir(cleanupTempCmd))
 	}
 	return rootCmd
 }

--- a/cmd/transform_next.go
+++ b/cmd/transform_next.go
@@ -12,3 +12,11 @@ var transformNextCmd = &cobra.Command{
 		return transformnext.Transform(dir)
 	},
 }
+
+var cleanupTempCmd = &cobra.Command{
+	Use:   "cleanup",
+	Short: "Clean-up temporary ETL files",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return transformnext.Cleanup()
+	},
+}


### PR DESCRIPTION
Utilitário para excluir arquivos temporários (banco de dados Badger) de processos do ETL que falharam.
